### PR TITLE
Fix missing Sanity blog fetch

### DIFF
--- a/frontend/src/lib/sanity.spec.ts
+++ b/frontend/src/lib/sanity.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test, vi } from 'vitest';
+import { getBlogPosts } from './sanity';
+
+vi.mock('@sanity/client', () => {
+  return {
+    createClient: () => ({ fetch: vi.fn(() => Promise.resolve([])) })
+  };
+});
+
+test('getBlogPosts returns an array', async () => {
+  const posts = await getBlogPosts();
+  expect(Array.isArray(posts)).toBe(true);
+});

--- a/frontend/src/lib/sanity.ts
+++ b/frontend/src/lib/sanity.ts
@@ -3,6 +3,8 @@ import { createClient, type SanityClient } from '@sanity/client'
 import type { Navigation } from '$lib/types/navigation'
 import type { DesignToken } from '$lib/types/designToken'
 
+import type { BlogPost } from "$lib/types/blogPost"
+
 const client: SanityClient = createClient({
   projectId: 'smxz6rsz',
   dataset:   'production',
@@ -22,10 +24,23 @@ export async function getNavigation(): Promise<Navigation | null> {
     return null
   }
 }
-
 export async function getDesignToken(): Promise<DesignToken | null> {
   const tokens = await client.fetch<DesignToken[]>(`
     *[_type=="designToken"] | order(_createdAt desc)[0]
-  `)
-  return tokens[0] || null
+  `);
+  return tokens[0] || null;
+}
+export async function getBlogPosts(): Promise<BlogPost[]> {
+  const query = `*[_type=="blogPost"] | order(publishedAt desc){
+    _id,
+    title,
+    slug,
+    excerpt
+  }`;
+  try {
+    return await client.fetch<BlogPost[]>(query);
+  } catch (err) {
+    console.error('Sanity fetch error for blog posts:', err);
+    return [];
+  }
 }

--- a/frontend/src/lib/types/blogPost.ts
+++ b/frontend/src/lib/types/blogPost.ts
@@ -1,0 +1,6 @@
+export interface BlogPost {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  excerpt: string;
+}


### PR DESCRIPTION
## Summary
- implement `getBlogPosts` in Sanity helper
- add BlogPost type definition
- test the new helper

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688984b2de048332b52d5e21dad14fe0