### PR TITLE
Fix single DesignToken fetch

### DIFF
--- a/frontend/src/lib/sanity.ts
+++ b/frontend/src/lib/sanity.ts
@@ -24,8 +24,11 @@ export async function getNavigation(): Promise<Navigation | null> {
 }
 
 export async function getDesignToken(): Promise<DesignToken | null> {
-  const tokens = await client.fetch<DesignToken[]>(`
-    *[_type=="designToken"] | order(_createdAt desc)[0]
-  `)
-  return tokens[0] || null
+  const query = `*[_type=="designToken"] | order(_createdAt desc)[0]`
+  try {
+    return await client.fetch<DesignToken>(query)
+  } catch (err) {
+    console.error('Sanity fetch error for design token:', err)
+    return null
+  }
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,15 +7,15 @@
 	import type { Navigation } from '$lib/types/navigation';
   
 	// whatever the server returned
-	export let data: {
-	  tokens:       DesignToken[];
-	  navigation:   Navigation | null;
-	};
+        export let data: {
+          tokens:       DesignToken | null;
+          navigation:   Navigation | null;
+        };
   
 	// apply tokens on the client
-	if (browser && data.tokens?.length > 0) {
-	  applyTokens(data.tokens[0]);
-	}
+        if (browser && data.tokens) {
+          applyTokens(data.tokens);
+        }
   
 	function applyTokens(token: DesignToken) {
 	  const root = document.documentElement;


### PR DESCRIPTION
## Summary
- fetch a single design token in Sanity client
- expect a single design token in layout data
- simplify client-side token handling

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889876b6f5083329142434b05259396