### PR TITLE
Add header color tokens and fix logo flicker

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,152 +1,178 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700;800&family=Source+Code+Pro:wght@400;500&display=swap');
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* =====================
    Design Token Variables
    ===================== */
 :root {
-  /* Typography */
-  --font-family: system-ui, sans-serif;
-  --font-family-heading: var(--font-family);
-  --font-size-base: 16px;
-  --font-weight: 400;
+	/* Typography */
+	--font-family: system-ui, sans-serif;
+	--font-family-heading: var(--font-family);
+	--font-size-base: 16px;
+	--font-weight: 400;
 
-  /* Colors (will be overwritten by JS) */
-  --color-background: #ffffff;
-  --color-foreground: #000000;
-  --color-primary: #3b82f6;
+	/* Colors (will be overwritten by JS) */
+	--color-background: #ffffff;
+	--color-foreground: #000000;
+	--color-primary: #3b82f6;
 }
 
 /* =====================
    Base Styles
    ===================== */
 body {
-  font-family: var(--font-family);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight);
-  color: var(--color-foreground);
-  background-color: var(--color-background);
-  transition: background-color 0.3s ease, color 0.3s ease;
+	font-family: var(--font-family);
+	font-size: var(--font-size-base);
+	font-weight: var(--font-weight);
+	color: var(--color-foreground);
+	background-color: var(--color-background);
+	transition:
+		background-color 0.3s ease,
+		color 0.3s ease;
 }
 
 /* Headings */
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-family-heading);
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-family: var(--font-family-heading);
 }
 
 /* =====================
    Tailwind Utility Overrides
    ===================== */
-.bg-background { background-color: var(--color-background); }
-.text-foreground { color: var(--color-foreground); }
-.text-primary { color: var(--color-primary); }
-.border-foreground { border-color: var(--color-foreground); }
-.hover\:text-primary:hover { color: var(--color-primary); }
+.bg-background {
+	background-color: var(--color-background);
+}
+.text-foreground {
+	color: var(--color-foreground);
+}
+.bg-header {
+	background-color: var(--color-headerBackground);
+}
+.text-header {
+	color: var(--color-headerText);
+}
+.text-primary {
+	color: var(--color-primary);
+}
+.border-foreground {
+	border-color: var(--color-foreground);
+}
+.hover\:text-primary:hover {
+	color: var(--color-primary);
+}
 
 /* =====================
    Navigation Links
    ===================== */
 .nav-link {
-  font-family: var(--font-family-heading);
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-foreground);
-  transition: color 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  display: inline-flex;
-  align-items: center;
-  min-height: 48px; /* Match logo height */
+	font-family: var(--font-family-heading);
+	font-weight: 800;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--color-headerText);
+	transition: color 0.3s ease;
+	position: relative;
+	overflow: hidden;
+	display: inline-flex;
+	align-items: center;
+	min-height: 48px; /* Match logo height */
 }
 .nav-link:hover {
-  color: var(--color-primary);
+	color: var(--color-primary);
 }
 .nav-link img {
-  display: block;
-  position: relative;
-  z-index: 10;
+	display: block;
+	position: relative;
+	z-index: 10;
 }
 .nav-link span {
-  display: block;
-  position: relative;
-  z-index: 0;
+	display: block;
+	position: relative;
+	z-index: 0;
 }
 
 /* =====================
    Buttons
    ===================== */
 button {
-  background-color: var(--color-primary);
-  color: var(--color-foreground);
-  font-family: var(--font-family);
-  transition: background-color 0.3s, color 0.3s;
+	background-color: var(--color-primary);
+	color: var(--color-foreground);
+	font-family: var(--font-family);
+	transition:
+		background-color 0.3s,
+		color 0.3s;
 }
 
 /* =====================
    Preload Font-Faces
    ===================== */
 @font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 400 800;
-  src: url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700;800&display=swap') format('woff2');
+	font-family: 'Poppins';
+	font-style: normal;
+	font-weight: 400 800;
+	src: url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700;800&display=swap')
+		format('woff2');
 }
 @font-face {
-  font-family: 'Source Code Pro';
-  font-style: normal;
-  font-weight: 400 500;
-  src: url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500&display=swap') format('woff2');
+	font-family: 'Source Code Pro';
+	font-style: normal;
+	font-weight: 400 500;
+	src: url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500&display=swap')
+		format('woff2');
 }
 /* Logo container always reserves space */
 .logo-link {
-  display: inline-flex;
-  align-items: center;
+	display: inline-flex;
+	align-items: center;
 }
 
 /* Hide/show via data-has-logo */
-header[data-has-logo="true"] .logo-text {
-  display: none;
+header[data-has-logo='true'] .logo-text {
+	display: none;
 }
-header[data-has-logo="false"] .logo-img {
-  display: none;
+header[data-has-logo='false'] .logo-img {
+	display: none;
 }
 
 /* Ensure crisp scaling */
 /* No fixed Tailwind h-8 here; we use the <img>'s intrinsic 120×40 box */
 .logo-img {
-  /* width: 128px; */
-  height: 48px; /* Increased proportionally */
-  object-fit: contain;
-  transform: translateZ(0); /* Force GPU acceleration */
-  backface-visibility: hidden; 
-  -webkit-font-smoothing: antialiased;
-  image-rendering: -webkit-optimize-contrast;
-  image-rendering: crisp-edges;
-  will-change: transform;
-  display: block; /* Prevent line height issues */
-  
+	/* width: 128px; */
+	height: 48px; /* Increased proportionally */
+	object-fit: contain;
+	transform: translateZ(0); /* Force GPU acceleration */
+	backface-visibility: hidden;
+	-webkit-font-smoothing: antialiased;
+	image-rendering: -webkit-optimize-contrast;
+	image-rendering: crisp-edges;
+	will-change: transform;
+	display: block; /* Prevent line height issues */
 }
 
 /* Add or update this container class */
 .site-container {
-  width: 100%;
-  max-width: 1280px; /* Adjust this to your preferred max width */
-  margin: 0 auto;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+	width: 100%;
+	max-width: 1280px; /* Adjust this to your preferred max width */
+	margin: 0 auto;
+	padding-left: 1.5rem;
+	padding-right: 1.5rem;
 }
 
 @media (min-width: 768px) {
-  .site-container {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
+	.site-container {
+		padding-left: 2rem;
+		padding-right: 2rem;
+	}
 }
 
 @media (min-width: 1024px) {
-  .site-container {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
-  }
+	.site-container {
+		padding-left: 2.5rem;
+		padding-right: 2.5rem;
+	}
 }

--- a/frontend/src/lib/Header.svelte
+++ b/frontend/src/lib/Header.svelte
@@ -1,191 +1,195 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from 'svelte';
-  import ThemeToggle from '$lib/ThemeToggle.svelte';
-  import type { Navigation, NavItem } from '$lib/types/navigation';
-  import { fade } from 'svelte/transition';
-  import { urlFor, logoSrcsetWebp } from '$lib/utils/sanityImage';
-  import { browser } from '$app/environment';
-  import { logoCache } from '$lib/stores/logoStore';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import ThemeToggle from '$lib/ThemeToggle.svelte';
+	import type { Navigation, NavItem } from '$lib/types/navigation';
+	import { fade } from 'svelte/transition';
+	import { urlFor, logoSrcsetWebp } from '$lib/utils/sanityImage';
+	import { browser } from '$app/environment';
+	import { logoCache } from '$lib/stores/logoStore';
 
-  /** Props **/
-  export let navigation: Navigation | null;
-  export let currentTheme: 'light' | 'dark' = 'light';
-  export let currentThemeData: any = {};
+	/** Props **/
+	export let navigation: Navigation | null;
+	export let currentTheme: 'light' | 'dark' = 'light';
+	export let currentThemeData: any = {};
 
-  /** Local state **/
-  let mobileMenuOpen = false;
-  let headerElement: HTMLElement;
-  let logoUrl = '';
-  let logoSrcset = '';
-  let logoAlt = '';
-  
-  /** Process logo data once when component mounts or theme changes **/
-  $: if (browser && currentThemeData?.logo?.asset?._ref) {
-    // First check if we already have this logo cached
-    if (!$logoCache || $logoCache.alt !== currentThemeData.themeName) {
-      // Generate high quality logo URL - using 3x size for sharpness
-      logoUrl = urlFor(currentThemeData.logo)
-        .width(360) // Triple size for sharpness
-        .auto('format')
-        .quality(95) // Higher quality for logo
-        .url();
-        
-      logoSrcset = logoSrcsetWebp(currentThemeData.logo, 360, 95, 'webp');
-      logoAlt = currentThemeData.themeName || 'Site Logo';
-      
-      // Store in the persistent cache
-      logoCache.set({
-        url: logoUrl,
-        srcset: logoSrcset,
-        alt: logoAlt
-      });
-    } else {
-      // Use cached values
-      logoUrl = $logoCache.url;
-      logoSrcset = $logoCache.srcset;
-      logoAlt = $logoCache.alt;
-    }
-  }
+	/** Local state **/
+	let mobileMenuOpen = false;
+	let headerElement: HTMLElement;
+	let logoUrl = '';
+	let logoSrcset = '';
+	let logoAlt = '';
 
-  /** Show logo whenever data includes a logo reference or we have cached data **/
-  $: showLogo = Boolean(currentThemeData?.logo?.asset?._ref) || Boolean($logoCache);
+	/** Process logo data once when component mounts or theme changes **/
+	$: if (currentThemeData?.logo?.asset?._ref) {
+		// First check if we already have this logo cached
+		if (!$logoCache || $logoCache.alt !== currentThemeData.themeName) {
+			// Generate high quality logo URL - using 3x size for sharpness
+			logoUrl = urlFor(currentThemeData.logo)
+				.width(360) // Triple size for sharpness
+				.auto('format')
+				.quality(95) // Higher quality for logo
+				.url();
 
-  /** Theme-change dispatcher **/
-  const dispatch = createEventDispatcher<{ themeChange: { theme: 'light' | 'dark' } }>();
+			logoSrcset = logoSrcsetWebp(currentThemeData.logo, 360, 95, 'webp');
+			logoAlt = currentThemeData.themeName || 'Site Logo';
 
-  onMount(() => {
-    document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
-  });
+			// Store in the persistent cache
+			logoCache.set({
+				url: logoUrl,
+				srcset: logoSrcset,
+				alt: logoAlt
+			});
+		} else {
+			// Use cached values
+			logoUrl = $logoCache.url;
+			logoSrcset = $logoCache.srcset;
+			logoAlt = $logoCache.alt;
+		}
+	}
 
-  /** Dispatch theme changes upward **/
-  function handleThemeChange(event: CustomEvent<{ theme: 'light' | 'dark' }>) {
-    dispatch('themeChange', event.detail);
-  }
+	/** Show logo whenever data includes a logo reference or we have cached data **/
+	$: showLogo = Boolean(currentThemeData?.logo?.asset?._ref) || Boolean($logoCache);
 
-  /** Normalize links **/
-  function getHref(item: NavItem): string {
-    if (typeof item.link === 'string') return item.link;
-    if (item.link?.external) return item.link.external;
-    const slug = item.link?.internal?.slug?.current;
-    return slug ? `/${slug}` : '#';
-  }
+	/** Theme-change dispatcher **/
+	const dispatch = createEventDispatcher<{ themeChange: { theme: 'light' | 'dark' } }>();
 
-  /** Mobile menu toggle **/
-  function toggleMobileMenu() {
-    mobileMenuOpen = !mobileMenuOpen;
-  }
+	onMount(() => {
+		document.addEventListener('click', handleClickOutside);
+		return () => document.removeEventListener('click', handleClickOutside);
+	});
 
-  /** Click-away to close mobile menu **/
-  function handleClickOutside(event: MouseEvent) {
-    if (mobileMenuOpen && headerElement && !headerElement.contains(event.target as Node)) {
-      mobileMenuOpen = false;
-    }
-  }
+	/** Dispatch theme changes upward **/
+	function handleThemeChange(event: CustomEvent<{ theme: 'light' | 'dark' }>) {
+		dispatch('themeChange', event.detail);
+	}
+
+	/** Normalize links **/
+	function getHref(item: NavItem): string {
+		if (typeof item.link === 'string') return item.link;
+		if (item.link?.external) return item.link.external;
+		const slug = item.link?.internal?.slug?.current;
+		return slug ? `/${slug}` : '#';
+	}
+
+	/** Mobile menu toggle **/
+	function toggleMobileMenu() {
+		mobileMenuOpen = !mobileMenuOpen;
+	}
+
+	/** Click-away to close mobile menu **/
+	function handleClickOutside(event: MouseEvent) {
+		if (mobileMenuOpen && headerElement && !headerElement.contains(event.target as Node)) {
+			mobileMenuOpen = false;
+		}
+	}
 </script>
 
-<header bind:this={headerElement} class="bg-background border-b border-gray-200 dark:border-gray-700">
-  <nav class="site-container"> <!-- Replace mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 with site-container -->
-    <div class="flex justify-between items-center h-16">
-      <!-- Logo / Brand -->
-      <div class="flex-shrink-0">
-        <a href="/" class="nav-link flex items-center space-x-2">
-          {#if showLogo && (logoUrl || ($logoCache && $logoCache.url))}
-            <img
-              src={logoUrl || $logoCache.url}
-              alt={logoAlt || $logoCache?.alt || 'Site Logo'}
-              class="logo-img"
-              fetchpriority="high"
-              loading="eager"
-              decoding="async"
-            />
-          {:else}
-            <span class="text-xl font-bold text-foreground">Greg D. Chan</span>
-          {/if}
-        </a>
-      </div>
+<header
+	bind:this={headerElement}
+	class="bg-header text-header border-b border-gray-200 dark:border-gray-700"
+>
+	<nav class="site-container">
+		<!-- Replace mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 with site-container -->
+		<div class="flex h-16 items-center justify-between">
+			<!-- Logo / Brand -->
+			<div class="flex-shrink-0">
+				<a href="/" class="nav-link flex items-center space-x-2">
+					{#if showLogo && (logoUrl || ($logoCache && $logoCache.url))}
+						<img
+							src={logoUrl || $logoCache.url}
+							alt={logoAlt || $logoCache?.alt || 'Site Logo'}
+							class="logo-img"
+							fetchpriority="high"
+							loading="eager"
+							decoding="async"
+						/>
+					{:else}
+						<span class="text-xl font-bold">Greg D. Chan</span>
+					{/if}
+				</a>
+			</div>
 
-      <!-- Desktop nav + theme toggle + mobile button -->
-      <div class="flex items-center space-x-6">
-        <div class="hidden md:block">
-          <div class="flex items-baseline space-x-4">
-            {#if navigation?.items}
-              {#each navigation.items as item}
-                <a
-                  href={getHref(item)}
-                  class="nav-link text-foreground hover:text-primary px-3 py-2 rounded-md text-sm transition-colors"
-                  target={item.target || '_self'}
-                >
-                  {item.text}
-                </a>
-              {/each}
-            {/if}
-          </div>
-        </div>
+			<!-- Desktop nav + theme toggle + mobile button -->
+			<div class="flex items-center space-x-6">
+				<div class="hidden md:block">
+					<div class="flex items-baseline space-x-4">
+						{#if navigation?.items}
+							{#each navigation.items as item}
+								<a
+									href={getHref(item)}
+									class="nav-link hover:text-primary rounded-md px-3 py-2 text-sm transition-colors"
+									target={item.target || '_self'}
+								>
+									{item.text}
+								</a>
+							{/each}
+						{/if}
+					</div>
+				</div>
 
-        <ThemeToggle {currentTheme} on:themeChange={handleThemeChange} />
+				<ThemeToggle {currentTheme} on:themeChange={handleThemeChange} />
 
-        <div class="md:hidden">
-          <button
-            type="button"
-            on:click|stopPropagation={toggleMobileMenu}
-            class="bg-background inline-flex items-center justify-center p-2 rounded-md text-foreground hover:text-primary focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary w-10 h-10"
-            aria-controls="mobile-menu"
-            aria-expanded={mobileMenuOpen}
-          >
-            <span class="sr-only">{mobileMenuOpen ? 'Close menu' : 'Open menu'}</span>
-            <div class="w-6 h-6 relative flex items-center justify-center">
-              <span
-                class="absolute h-0.5 w-6 bg-current transition-all duration-300 ease-in-out origin-center"
-                style={mobileMenuOpen ? 'transform: rotate(45deg);' : 'transform: translateY(-4px);'}
-              />
-              <span
-                class="absolute h-0.5 w-6 bg-current transition-all duration-300 ease-in-out"
-                style={mobileMenuOpen ? 'opacity: 0; transform: scale(0);' : 'opacity: 1;'}
-              />
-              <span
-                class="absolute h-0.5 w-6 bg-current transition-all duration-300 ease-in-out origin-center"
-                style={mobileMenuOpen ? 'transform: rotate(-45deg);' : 'transform: translateY(4px);'}
-              />
-            </div>
-          </button>
-        </div>
-      </div>
-    </div>
+				<div class="md:hidden">
+					<button
+						type="button"
+						on:click|stopPropagation={toggleMobileMenu}
+						class="bg-header text-header hover:text-primary focus:ring-primary inline-flex h-10 w-10 items-center justify-center rounded-md p-2 focus:ring-2 focus:outline-none focus:ring-inset"
+						aria-controls="mobile-menu"
+						aria-expanded={mobileMenuOpen}
+					>
+						<span class="sr-only">{mobileMenuOpen ? 'Close menu' : 'Open menu'}</span>
+						<div class="relative flex h-6 w-6 items-center justify-center">
+							<span
+								class="absolute h-0.5 w-6 origin-center bg-current transition-all duration-300 ease-in-out"
+								style={mobileMenuOpen
+									? 'transform: rotate(45deg);'
+									: 'transform: translateY(-4px);'}
+							/>
+							<span
+								class="absolute h-0.5 w-6 bg-current transition-all duration-300 ease-in-out"
+								style={mobileMenuOpen ? 'opacity: 0; transform: scale(0);' : 'opacity: 1;'}
+							/>
+							<span
+								class="absolute h-0.5 w-6 origin-center bg-current transition-all duration-300 ease-in-out"
+								style={mobileMenuOpen
+									? 'transform: rotate(-45deg);'
+									: 'transform: translateY(4px);'}
+							/>
+						</div>
+					</button>
+				</div>
+			</div>
+		</div>
 
-    {#if mobileMenuOpen}
-      <div
-        id="mobile-menu"
-        class="md:hidden"
-        transition:fade={{ duration: 200 }}
-      >
-        <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-          {#if navigation?.items}
-            {#each navigation.items as item}
-              <a
-                href={getHref(item)}
-                class="text-foreground hover:text-primary block px-3 py-2 rounded-md text-sm font-normal border-l-2 border-transparent hover:border-primary transition-all"
-                target={item.target || '_self'}
-              >
-                {item.text}
-              </a>
-              {#if item.children?.length}
-                <div class="pl-4 space-y-1">
-                  {#each item.children as child}
-                    <a
-                      href={getHref(child)}
-                      class="text-foreground hover:text-primary block px-3 py-2 rounded-md text-sm font-normal"
-                      target={child.target || '_self'}
-                    >
-                      {child.text}
-                    </a>
-                  {/each}
-                </div>
-              {/if}
-            {/each}
-          {/if}
-        </div>
-      </div>
-    {/if}
-  </nav>
+		{#if mobileMenuOpen}
+			<div id="mobile-menu" class="md:hidden" transition:fade={{ duration: 200 }}>
+				<div class="space-y-1 px-2 pt-2 pb-3 sm:px-3">
+					{#if navigation?.items}
+						{#each navigation.items as item}
+							<a
+								href={getHref(item)}
+								class="text-header hover:text-primary hover:border-primary block rounded-md border-l-2 border-transparent px-3 py-2 text-sm font-normal transition-all"
+								target={item.target || '_self'}
+							>
+								{item.text}
+							</a>
+							{#if item.children?.length}
+								<div class="space-y-1 pl-4">
+									{#each item.children as child}
+										<a
+											href={getHref(child)}
+											class="text-header hover:text-primary block rounded-md px-3 py-2 text-sm font-normal"
+											target={child.target || '_self'}
+										>
+											{child.text}
+										</a>
+									{/each}
+								</div>
+							{/if}
+						{/each}
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</nav>
 </header>

--- a/frontend/src/lib/types/designToken.ts
+++ b/frontend/src/lib/types/designToken.ts
@@ -8,6 +8,10 @@ export interface DesignToken {
 		secondary?: { hex: string };
 		background?: { hex: string };
 		foreground?: { hex: string };
+		headerBackground?: { hex: string };
+		headerText?: { hex: string };
+		bodyBackground?: { hex: string };
+		bodyText?: { hex: string };
 		accent?: { hex: string };
 		muted?: { hex: string };
 	};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,223 +1,182 @@
 <script lang="ts">
-  import Header from '$lib/Header.svelte';
-  import Footer from '$lib/Footer.svelte';
-  import { browser } from '$app/environment';
-  import type { DesignToken } from '$lib/types/designToken';
-  import type { Navigation } from '$lib/types/navigation';
-  import '../app.css';
-  import { fade } from 'svelte/transition';
-  import { theme } from '$lib/stores/themeStore';
-  import { onMount, onDestroy } from 'svelte';
-  import { get } from 'svelte/store';
+	import Header from '$lib/Header.svelte';
+	import Footer from '$lib/Footer.svelte';
+	import { browser } from '$app/environment';
+	import type { DesignToken } from '$lib/types/designToken';
+	import type { Navigation } from '$lib/types/navigation';
+	import '../app.css';
+	import { fade } from 'svelte/transition';
+	import { theme } from '$lib/stores/themeStore';
+	import { onMount, onDestroy } from 'svelte';
+	import { get } from 'svelte/store';
 
-  export let data: {
-    tokens: { light: DesignToken | null; dark: DesignToken | null };
-    navigation: Navigation | null;
-  };
+	export let data: {
+		tokens: { light: DesignToken | null; dark: DesignToken | null };
+		navigation: Navigation | null;
+	};
 
-  let currentThemeData: DesignToken | null = null;
-  let unsubscribeTheme: () => void;
+	let currentThemeData: DesignToken | null = data.tokens.light || data.tokens.dark || null;
+	let unsubscribeTheme: () => void;
 
-  let isInitialLoad = true;
-  let isHomePage = false;
+	let isInitialLoad = true;
+	let isHomePage = false;
 
-  function applyTokens(tokenSet: DesignToken) {
-    // — COLORS —
-    for (const [key, val] of Object.entries(tokenSet.colors || {})) {
-      if ((val as any)?.hex) {
-        document.documentElement.style.setProperty(
-          `--color-${key}`,
-          (val as any).hex
-        );
-      }
-    }
+	function applyTokens(tokenSet: DesignToken) {
+		// — COLORS —
+		for (const [key, val] of Object.entries(tokenSet.colors || {})) {
+			if ((val as any)?.hex) {
+				document.documentElement.style.setProperty(`--color-${key}`, (val as any).hex);
+				if (key === 'bodyBackground') {
+					document.documentElement.style.setProperty('--color-background', (val as any).hex);
+				}
+				if (key === 'bodyText') {
+					document.documentElement.style.setProperty('--color-foreground', (val as any).hex);
+				}
+			}
+		}
 
-    // — TYPOGRAPHY —
-    const ty = tokenSet.typography;
-    if (ty) {
-      // Body font-family
-      const bf =
-        ty.bodyFontFamily === 'custom'
-          ? ty.customBodyFontFamily
-          : ty.bodyFontFamily;
-      if (bf && bf !== 'custom') {
-        document.documentElement.style.setProperty('--font-family', bf);
-      }
+		// — TYPOGRAPHY —
+		const ty = tokenSet.typography;
+		if (ty) {
+			// Body font-family
+			const bf = ty.bodyFontFamily === 'custom' ? ty.customBodyFontFamily : ty.bodyFontFamily;
+			if (bf && bf !== 'custom') {
+				document.documentElement.style.setProperty('--font-family', bf);
+			}
 
-      // Base font-size
-      if (typeof ty.baseFontSize === 'number' && ty.baseFontSize > 0) {
-        document.documentElement.style.setProperty(
-          '--font-size-base',
-          `${ty.baseFontSize}px`
-        );
-      }
+			// Base font-size
+			if (typeof ty.baseFontSize === 'number' && ty.baseFontSize > 0) {
+				document.documentElement.style.setProperty('--font-size-base', `${ty.baseFontSize}px`);
+			}
 
-      // Base font-weight
-      if (ty.baseFontWeight) {
-        document.documentElement.style.setProperty(
-          '--font-weight',
-          ty.baseFontWeight
-        );
-      }
+			// Base font-weight
+			if (ty.baseFontWeight) {
+				document.documentElement.style.setProperty('--font-weight', ty.baseFontWeight);
+			}
 
-      // Header font-family
-      const hf =
-        ty.headerFontFamily === 'inherit'
-          ? bf
-          : ty.headerFontFamily === 'custom'
-          ? ty.customHeaderFontFamily
-          : ty.headerFontFamily;
-      if (hf && hf !== 'custom') {
-        document.documentElement.style.setProperty(
-          '--font-family-heading',
-          hf
-        );
-      }
-    }
-  }
+			// Header font-family
+			const hf =
+				ty.headerFontFamily === 'inherit'
+					? bf
+					: ty.headerFontFamily === 'custom'
+						? ty.customHeaderFontFamily
+						: ty.headerFontFamily;
+			if (hf && hf !== 'custom') {
+				document.documentElement.style.setProperty('--font-family-heading', hf);
+			}
+		}
+	}
 
-  onMount(() => {
-    // 1) Homepage fade
-    isHomePage = window.location.pathname === '/';
-    setTimeout(() => (isInitialLoad = false), 200);
+	onMount(() => {
+		// 1) Homepage fade
+		isHomePage = window.location.pathname === '/';
+		setTimeout(() => (isInitialLoad = false), 200);
 
-    if (!browser) return;
+		if (!browser) return;
 
-    // 2) Figure out initial theme
-    const initTheme = get(theme);
-    currentThemeData =
-      initTheme === 'dark' ? data.tokens.dark : data.tokens.light;
+		// 2) Figure out initial theme
+		const initTheme = get(theme);
+		currentThemeData = initTheme === 'dark' ? data.tokens.dark : data.tokens.light;
 
-    // 3) Apply it once
-    if (currentThemeData) {
-      applyTokens(currentThemeData);
-      // cache to localStorage
-      localStorage.setItem(
-        'designTokens',
-        JSON.stringify(data.tokens)
-      );
-    }
+		// 3) Apply it once
+		if (currentThemeData) {
+			applyTokens(currentThemeData);
+			// cache to localStorage
+			localStorage.setItem('designTokens', JSON.stringify(data.tokens));
+		}
 
-    // 4) Subscribe so toggles reapply instantly
-    unsubscribeTheme = theme.subscribe((t) => {
-      document.documentElement.classList.toggle('dark', t === 'dark');
-      const ts = t === 'dark' ? data.tokens.dark : data.tokens.light;
-      if (ts) {
-        currentThemeData = ts;
-        applyTokens(ts);
-        localStorage.setItem(
-          'designTokens',
-          JSON.stringify(data.tokens)
-        );
-      }
-    });
-  });
+		// 4) Subscribe so toggles reapply instantly
+		unsubscribeTheme = theme.subscribe((t) => {
+			document.documentElement.classList.toggle('dark', t === 'dark');
+			const ts = t === 'dark' ? data.tokens.dark : data.tokens.light;
+			if (ts) {
+				currentThemeData = ts;
+				applyTokens(ts);
+				localStorage.setItem('designTokens', JSON.stringify(data.tokens));
+			}
+		});
+	});
 
-  onDestroy(() => {
-    unsubscribeTheme && unsubscribeTheme();
-  });
+	onDestroy(() => {
+		unsubscribeTheme && unsubscribeTheme();
+	});
 </script>
 
 <svelte:head>
-  <title>Greg D. Chan</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Greg D. Chan</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <!--
+	<!--
     Pre-hydrate theme class + CSS variables from last session.
     Prevents FOUC/blink when you navigate or reload.
   -->
-  <script>
-    (function () {
-      const storedTheme =
-        localStorage.getItem('theme') ||
-        (window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light');
-      document.documentElement.classList.toggle(
-        'dark',
-        storedTheme === 'dark'
-      );
+	<script>
+		(function () {
+			const storedTheme =
+				localStorage.getItem('theme') ||
+				(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+			document.documentElement.classList.toggle('dark', storedTheme === 'dark');
 
-      let tokens = {};
-      try {
-        tokens = JSON.parse(localStorage.getItem('designTokens')) || {};
-      } catch {}
-      const tokenSet = tokens[storedTheme] || {};
+			let tokens = {};
+			try {
+				tokens = JSON.parse(localStorage.getItem('designTokens')) || {};
+			} catch {}
+			const tokenSet = tokens[storedTheme] || {};
 
-      // Apply colors
-      if (tokenSet.colors) {
-        Object.entries(tokenSet.colors).forEach(([k, v]) => {
-          if (v?.hex) {
-            document.documentElement.style.setProperty(
-              `--color-${k}`,
-              v.hex
-            );
-          }
-        });
-      }
+			// Apply colors
+			if (tokenSet.colors) {
+				Object.entries(tokenSet.colors).forEach(([k, v]) => {
+					if (v?.hex) {
+						document.documentElement.style.setProperty(`--color-${k}`, v.hex);
+						if (k === 'bodyBackground') {
+							document.documentElement.style.setProperty('--color-background', v.hex);
+						}
+						if (k === 'bodyText') {
+							document.documentElement.style.setProperty('--color-foreground', v.hex);
+						}
+					}
+				});
+			}
 
-      // Apply typography
-      if (tokenSet.typography) {
-        const ty = tokenSet.typography;
-        const bf =
-          ty.bodyFontFamily === 'custom'
-            ? ty.customBodyFontFamily
-            : ty.bodyFontFamily;
-        if (bf) {
-          document.documentElement.style.setProperty(
-            '--font-family',
-            bf
-          );
-        }
-        if (ty.baseFontSize > 0) {
-          document.documentElement.style.setProperty(
-            '--font-size-base',
-            `${ty.baseFontSize}px`
-          );
-        }
-        if (ty.baseFontWeight) {
-          document.documentElement.style.setProperty(
-            '--font-weight',
-            ty.baseFontWeight
-          );
-        }
-        const hf =
-          ty.headerFontFamily === 'inherit'
-            ? bf
-            : ty.headerFontFamily === 'custom'
-            ? ty.customHeaderFontFamily
-            : ty.headerFontFamily;
-        if (hf) {
-          document.documentElement.style.setProperty(
-            '--font-family-heading',
-            hf
-          );
-        }
-      }
-    })();
-  </script>
+			// Apply typography
+			if (tokenSet.typography) {
+				const ty = tokenSet.typography;
+				const bf = ty.bodyFontFamily === 'custom' ? ty.customBodyFontFamily : ty.bodyFontFamily;
+				if (bf) {
+					document.documentElement.style.setProperty('--font-family', bf);
+				}
+				if (ty.baseFontSize > 0) {
+					document.documentElement.style.setProperty('--font-size-base', `${ty.baseFontSize}px`);
+				}
+				if (ty.baseFontWeight) {
+					document.documentElement.style.setProperty('--font-weight', ty.baseFontWeight);
+				}
+				const hf =
+					ty.headerFontFamily === 'inherit'
+						? bf
+						: ty.headerFontFamily === 'custom'
+							? ty.customHeaderFontFamily
+							: ty.headerFontFamily;
+				if (hf) {
+					document.documentElement.style.setProperty('--font-family-heading', hf);
+				}
+			}
+		})();
+	</script>
 </svelte:head>
 
 {#if isInitialLoad && isHomePage}
-  <div in:fade={{ duration: 150, delay: 150 }}>
-    <Header
-      navigation={data.navigation}
-      currentTheme={$theme}
-      currentThemeData={currentThemeData}
-    />
-    <main class="min-h-[90vh] bg-background text-foreground">
-      <slot />
-    </main>
-    <Footer />
-  </div>
+	<div in:fade={{ duration: 150, delay: 150 }}>
+		<Header navigation={data.navigation} currentTheme={$theme} {currentThemeData} />
+		<main class="bg-background text-foreground min-h-[90vh]">
+			<slot />
+		</main>
+		<Footer />
+	</div>
 {:else}
-  <Header
-    navigation={data.navigation}
-    currentTheme={$theme}
-    currentThemeData={currentThemeData}
-  />
-  <main class="min-h-[90vh] bg-background text-foreground">
-    <slot />
-  </main>
-  <Footer />
+	<Header navigation={data.navigation} currentTheme={$theme} {currentThemeData} />
+	<main class="bg-background text-foreground min-h-[90vh]">
+		<slot />
+	</main>
+	<Footer />
 {/if}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,90 +1,90 @@
 <script lang="ts">
-  import { urlFor } from '$lib/utils/sanityImage';
-  import { onMount } from 'svelte';
-  import PortableText from '$lib/components/PortableText.svelte';
-  
-  export let data;
-  const { homePage } = data;
-  
-  onMount(() => {
-    console.log('HomePage data:', homePage);
-  });
+	import { urlFor } from '$lib/utils/sanityImage';
+	import { onMount } from 'svelte';
+	import PortableText from '$lib/components/PortableText.svelte';
+
+	export let data;
+	const { homePage } = data;
+
+	onMount(() => {
+		console.log('HomePage data:', homePage);
+	});
 </script>
 
 <svelte:head>
-  <title>{homePage?.title || 'Home'}</title>
-  <meta name="description" content={homePage?.description || ''} />
+	<title>{homePage?.title || 'Home'}</title>
+	<meta name="description" content={homePage?.description || ''} />
 </svelte:head>
 
 <!-- Page content -->
-<div class="page-content">
-  {#if homePage?.title}
-    <h1 class="page-title">{homePage.title}</h1>
-  {/if}
+<div class="page-content site-container">
+	{#if homePage?.title}
+		<h1 class="page-title">{homePage.title}</h1>
+	{/if}
 
-  {#if homePage?.description}
-    <div class="page-description">{homePage.description}</div>
-  {/if}
+	{#if homePage?.description}
+		<div class="page-description">{homePage.description}</div>
+	{/if}
 
-  {#if homePage?.mainImage?.asset?._ref}
-    <div class="featured-image">
-      <img 
-        src={urlFor(homePage.mainImage).width(1200).auto('format').url()} 
-        alt={homePage.mainImage.alt || homePage.title} 
-      />
-    </div>
-  {/if}
+	{#if homePage?.mainImage?.asset?._ref}
+		<div class="featured-image">
+			<img
+				src={urlFor(homePage.mainImage).width(1200).auto('format').url()}
+				alt={homePage.mainImage.alt || homePage.title}
+			/>
+		</div>
+	{/if}
 
-  <!-- Render body content if available -->
-  {#if homePage?.body}
-    <div class="body-content">
-      <PortableText value={homePage.body} />
-    </div>
-  {/if}
+	<!-- Render body content if available -->
+	{#if homePage?.body}
+		<div class="body-content">
+			<PortableText value={homePage.body} />
+		</div>
+	{/if}
 
-  <!-- Render all section types -->
-  {#if homePage?.sections && homePage.sections.length > 0}
-    <div class="sections">
-      {#each homePage.sections as section (section._key)}
-        <!-- Hero Section -->
-        {#if section._type === 'hero'}
-          <section class="hero-section {section.backgroundType || 'color'}">
-            {#if section.backgroundType === 'image' && section.backgroundImage?.asset?._ref}
-              <div class="background">
-                <img 
-                  src={urlFor(section.backgroundImage).width(1600).auto('format').url()} 
-                  alt=""
-                  class="bg-image"
-                />
-              </div>
-            {/if}
-            
-            {#if section.backgroundType === 'video' && section.backgroundVideo}
-              <div class="background">
-                <video autoplay muted loop playsinline class="bg-video">
-                  <source src={section.backgroundVideo} type="video/mp4">
-                </video>
-              </div>
-            {/if}
-            
-            <div class="content">
-              {#if section.heading}
-                <h2>{section.heading}</h2>
-              {/if}
-              
-              {#if section.subheading}
-                <p class="subheading">{section.subheading}</p>
-              {/if}
-              
-              {#if section.cta?.text && section.cta?.url}
-                <a href={section.cta.url} class="cta-button">{section.cta.text}</a>
-              {/if}
-            </div>
-          </section>
-        {/if}
-        
-        <!-- Add other section types here -->
-        <!-- For example:
+	<!-- Render all section types -->
+	{#if homePage?.sections && homePage.sections.length > 0}
+		<div class="sections">
+			{#each homePage.sections as section (section._key)}
+				<!-- Hero Section -->
+				{#if section._type === 'hero'}
+					<section class="hero-section {section.backgroundType || 'color'}">
+						{#if section.backgroundType === 'image' && section.backgroundImage?.asset?._ref}
+							<div class="background">
+								<img
+									src={urlFor(section.backgroundImage).width(1600).auto('format').url()}
+									alt=""
+									class="bg-image"
+								/>
+							</div>
+						{/if}
+
+						{#if section.backgroundType === 'video' && section.backgroundVideo}
+							<div class="background">
+								<video autoplay muted loop playsinline class="bg-video">
+									<source src={section.backgroundVideo} type="video/mp4" />
+								</video>
+							</div>
+						{/if}
+
+						<div class="content">
+							{#if section.heading}
+								<h2>{section.heading}</h2>
+							{/if}
+
+							{#if section.subheading}
+								<p class="subheading">{section.subheading}</p>
+							{/if}
+
+							{#if section.cta?.text && section.cta?.url}
+								<a href={section.cta.url} class="cta-button">{section.cta.text}</a>
+							{/if}
+						</div>
+					</section>
+				{/if}
+
+				<!-- Add other section types here -->
+				<!-- For example:
         {#if section._type === 'textSection'}
           <section class="text-section">
             {#if section.heading}<h2>{section.heading}</h2>{/if}
@@ -92,96 +92,100 @@
           </section>
         {/if}
         -->
-      {/each}
-    </div>
-  {/if}
+			{/each}
+		</div>
+	{/if}
 </div>
 
 <style>
-  /* Basic styling */
-  .page-content {
-    padding: 2rem 0;
-  }
-  
-  .page-title {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-  }
-  
-  .page-description {
-    font-size: 1.25rem;
-    margin-bottom: 2rem;
-    max-width: 60ch;
-  }
-  
-  .featured-image {
-    margin-bottom: 2rem;
-  }
-  
-  .featured-image img {
-    width: 100%;
-    height: auto;
-    max-height: 500px;
-    object-fit: cover;
-  }
-  
-  /* Hero section styling */
-  .hero-section {
-    position: relative;
-    min-height: 60vh;
-    display: flex;
-    align-items: center;
-    margin-bottom: 2rem;
-    padding: 2rem;
-    overflow: hidden;
-  }
-  
-  .hero-section .background {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-  }
-  
-  .hero-section .bg-image,
-  .hero-section .bg-video {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-  
-  .hero-section .content {
-    position: relative;
-    z-index: 1;
-    max-width: 800px;
-  }
-  
-  .hero-section h2 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-  }
-  
-  .hero-section .subheading {
-    font-size: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  
-  .hero-section .cta-button {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background-color: var(--primary, #1a73e8);
-    color: white;
-    text-decoration: none;
-    border-radius: 4px;
-    font-weight: bold;
-  }
-  
-  /* Background types */
-  .hero-section.color {
-    background-color: #f5f5f5;
-  }
-  
-  .hero-section.image .content {
-    color: white;
-    text-shadow: 0 2px 4px rgba(0,0,0,0.5);
-  }
+	/* Basic styling */
+	.page-content {
+		padding: 2rem 0;
+	}
+
+	.page-title {
+		font-size: 2.5rem;
+		font-family: var(--font-family-heading);
+		margin-bottom: 1rem;
+	}
+
+	.page-description {
+		font-size: 1.25rem;
+		margin-bottom: 2rem;
+		max-width: 60ch;
+		font-family: var(--font-family);
+	}
+
+	.featured-image {
+		margin-bottom: 2rem;
+	}
+
+	.featured-image img {
+		width: 100%;
+		height: auto;
+		max-height: 500px;
+		object-fit: cover;
+	}
+
+	/* Hero section styling */
+	.hero-section {
+		position: relative;
+		min-height: 60vh;
+		display: flex;
+		align-items: center;
+		margin-bottom: 2rem;
+		padding: 2rem;
+		overflow: hidden;
+	}
+
+	.hero-section .background {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+	}
+
+	.hero-section .bg-image,
+	.hero-section .bg-video {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.hero-section .content {
+		position: relative;
+		z-index: 1;
+		max-width: 800px;
+	}
+
+	.hero-section h2 {
+		font-size: 3rem;
+		margin-bottom: 1rem;
+		font-family: var(--font-family-heading);
+	}
+
+	.hero-section .subheading {
+		font-size: 1.5rem;
+		margin-bottom: 1.5rem;
+		font-family: var(--font-family);
+	}
+
+	.hero-section .cta-button {
+		display: inline-block;
+		padding: 0.75rem 1.5rem;
+		background-color: var(--primary, #1a73e8);
+		color: white;
+		text-decoration: none;
+		border-radius: 4px;
+		font-weight: bold;
+	}
+
+	/* Background types */
+	.hero-section.color {
+		background-color: #f5f5f5;
+	}
+
+	.hero-section.image .content {
+		color: white;
+		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+	}
 </style>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,64 +2,68 @@
 const plugin = require('tailwindcss/plugin');
 
 module.exports = {
-  content: ['./src/**/*.{html,js,svelte,ts}'],
-  darkMode: 'class',
-  theme: {
-    extend: {
-      colors: {
-        primary: 'var(--color-primary)',
-        secondary: 'var(--color-secondary)',
-        background: 'var(--color-bg)',
-        foreground: 'var(--color-fg)',
-        accent: 'var(--color-accent)',
-        muted: 'var(--color-muted)'
-      },
-      fontFamily: {
-        custom: 'var(--font-family)',
-      },
-      fontSize: {
-        base: 'var(--font-size-base)',
-        h1: 'var(--font-size-h1)',
-        h2: 'var(--font-size-h2)',
-        h3: 'var(--font-size-h3)'
-      },
-      fontWeight: {
-        base: 'var(--font-weight)',
-        h1: 'var(--font-weight-h1)',
-        h2: 'var(--font-weight-h2)',
-        h3: 'var(--font-weight-h3)'
-      },
-      borderRadius: {
-        custom: 'var(--radius)'
-      },
-      boxShadow: {
-        custom: 'var(--box-shadow)'
-      }
-    }
-  },
-  plugins: [
-    plugin(function({ addBase }) {
-      addBase({
-        ':root': {
-          '--color-primary': '#1D4ED8',
-          '--color-secondary': '#9333EA',
-          '--color-bg': '#ffffff',
-          '--color-fg': '#000000',
-          '--color-accent': '#F59E0B',
-          '--color-muted': '#9CA3AF',
-          '--font-family': 'system-ui',
-          '--font-size-base': '16px',
-          '--font-size-h1': '40px',
-          '--font-size-h2': '32px',
-          '--font-size-h3': '28px',
-          '--font-weight': '400',
-          '--font-weight-h1': '800',
-          '--font-weight-h2': '700',
-          '--font-weight-h3': '600',
-          '--radius': '8px',
-          '--box-shadow': '0 4px 6px rgba(0,0,0,0.1)'
-        }
-      });
-    })
-  ]
+	content: ['./src/**/*.{html,js,svelte,ts}'],
+	darkMode: 'class',
+	theme: {
+		extend: {
+			colors: {
+				primary: 'var(--color-primary)',
+				secondary: 'var(--color-secondary)',
+				background: 'var(--color-bg)',
+				foreground: 'var(--color-fg)',
+				headerBackground: 'var(--color-headerBackground)',
+				headerText: 'var(--color-headerText)',
+				accent: 'var(--color-accent)',
+				muted: 'var(--color-muted)'
+			},
+			fontFamily: {
+				custom: 'var(--font-family)'
+			},
+			fontSize: {
+				base: 'var(--font-size-base)',
+				h1: 'var(--font-size-h1)',
+				h2: 'var(--font-size-h2)',
+				h3: 'var(--font-size-h3)'
+			},
+			fontWeight: {
+				base: 'var(--font-weight)',
+				h1: 'var(--font-weight-h1)',
+				h2: 'var(--font-weight-h2)',
+				h3: 'var(--font-weight-h3)'
+			},
+			borderRadius: {
+				custom: 'var(--radius)'
+			},
+			boxShadow: {
+				custom: 'var(--box-shadow)'
+			}
+		}
+	},
+	plugins: [
+		plugin(function ({ addBase }) {
+			addBase({
+				':root': {
+					'--color-primary': '#1D4ED8',
+					'--color-secondary': '#9333EA',
+					'--color-bg': '#ffffff',
+					'--color-fg': '#000000',
+					'--color-headerBackground': '#ffffff',
+					'--color-headerText': '#000000',
+					'--color-accent': '#F59E0B',
+					'--color-muted': '#9CA3AF',
+					'--font-family': 'system-ui',
+					'--font-size-base': '16px',
+					'--font-size-h1': '40px',
+					'--font-size-h2': '32px',
+					'--font-size-h3': '28px',
+					'--font-weight': '400',
+					'--font-weight-h1': '800',
+					'--font-weight-h2': '700',
+					'--font-weight-h3': '600',
+					'--radius': '8px',
+					'--box-shadow': '0 4px 6px rgba(0,0,0,0.1)'
+				}
+			});
+		})
+	]
 };

--- a/gregdchan/schemas/documents/designToken.js
+++ b/gregdchan/schemas/documents/designToken.js
@@ -1,182 +1,215 @@
-import { defineType, defineField } from 'sanity'
+import { defineType, defineField } from "sanity";
 
 export default defineType({
-  name: 'designToken',
-  title: 'Design Tokens',
-  type: 'document',
+  name: "designToken",
+  title: "Design Tokens",
+  type: "document",
   fields: [
     defineField({
-      name: 'themeName',
-      title: 'Theme Name',
-      type: 'string',
-      initialValue: 'default',
-      validation: Rule => Rule.required(),
+      name: "themeName",
+      title: "Theme Name",
+      type: "string",
+      initialValue: "default",
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: 'mode',
-      title: 'Mode (Light or Dark)',
-      type: 'string',
+      name: "mode",
+      title: "Mode (Light or Dark)",
+      type: "string",
       options: {
         list: [
-          { title: 'Light', value: 'light' },
-          { title: 'Dark', value: 'dark' },
+          { title: "Light", value: "light" },
+          { title: "Dark", value: "dark" },
         ],
-        layout: 'radio',
+        layout: "radio",
       },
-      validation: Rule => Rule.required(),
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: 'isDefault',
-      title: 'Is Default Theme for this Mode',
-      description: 'Make this the default theme for light or dark mode',
-      type: 'boolean',
+      name: "isDefault",
+      title: "Is Default Theme for this Mode",
+      description: "Make this the default theme for light or dark mode",
+      type: "boolean",
       initialValue: false,
     }),
 
     // Logo
     defineField({
-      name: 'logo',
-      title: 'Logo Image',
-      type: 'image',
+      name: "logo",
+      title: "Logo Image",
+      type: "image",
       options: { hotspot: true },
       fields: [
         defineField({
-          name: 'alt',
-          title: 'Alt Text',
-          type: 'string',
+          name: "alt",
+          title: "Alt Text",
+          type: "string",
         }),
       ],
     }),
 
     // Colors
     defineField({
-      name: 'colors',
-      title: 'Colors',
-      type: 'object',
+      name: "colors",
+      title: "Colors",
+      type: "object",
       fields: [
-        defineField({ name: 'primary', title: 'Primary', type: 'color' }),
-        defineField({ name: 'secondary', title: 'Secondary', type: 'color' }),
-        defineField({ name: 'background', title: 'Background', type: 'color' }),
-        defineField({ name: 'foreground', title: 'Foreground / Text', type: 'color' }),
-        defineField({ name: 'accent', title: 'Accent', type: 'color' }),
-        defineField({ name: 'muted', title: 'Muted', type: 'color' }),
+        defineField({ name: "primary", title: "Primary", type: "color" }),
+        defineField({ name: "secondary", title: "Secondary", type: "color" }),
+        defineField({ name: "background", title: "Background", type: "color" }),
+        defineField({
+          name: "foreground",
+          title: "Foreground / Text",
+          type: "color",
+        }),
+        defineField({
+          name: "headerBackground",
+          title: "Header Background",
+          type: "color",
+        }),
+        defineField({
+          name: "headerText",
+          title: "Header Text",
+          type: "color",
+        }),
+        defineField({
+          name: "bodyBackground",
+          title: "Body Background",
+          type: "color",
+        }),
+        defineField({ name: "bodyText", title: "Body Text", type: "color" }),
+        defineField({ name: "accent", title: "Accent", type: "color" }),
+        defineField({ name: "muted", title: "Muted", type: "color" }),
       ],
     }),
 
     // Typography
     defineField({
-      name: 'typography',
-      title: 'Typography',
-      type: 'object',
+      name: "typography",
+      title: "Typography",
+      type: "object",
       fields: [
         // Body Font
         defineField({
-          name: 'bodyFontFamily',
-          title: 'Body Font Family',
-          type: 'string',
+          name: "bodyFontFamily",
+          title: "Body Font Family",
+          type: "string",
           options: {
             list: [
-              { title: 'System UI', value: 'system-ui' },
-              { title: 'Inter', value: 'Inter, sans-serif' },
-              { title: 'Poppins', value: 'Poppins, sans-serif' },
-              { title: 'Roboto', value: 'Roboto, sans-serif' },
-              { title: 'Georgia', value: 'Georgia, serif' },
-              { title: 'Custom', value: 'custom' },
+              { title: "System UI", value: "system-ui" },
+              { title: "Inter", value: "Inter, sans-serif" },
+              { title: "Poppins", value: "Poppins, sans-serif" },
+              { title: "Roboto", value: "Roboto, sans-serif" },
+              { title: "Georgia", value: "Georgia, serif" },
+              { title: "Custom", value: "custom" },
             ],
           },
         }),
         defineField({
-          name: 'customBodyFontFamily',
-          title: 'Custom Body Font (optional)',
-          type: 'string',
-          hidden: ({ parent }) => !parent || parent.bodyFontFamily !== 'custom',
+          name: "customBodyFontFamily",
+          title: "Custom Body Font (optional)",
+          type: "string",
+          hidden: ({ parent }) => !parent || parent.bodyFontFamily !== "custom",
         }),
 
         // Header Font
         defineField({
-          name: 'headerFontFamily',
-          title: 'Header Font Family',
-          type: 'string',
+          name: "headerFontFamily",
+          title: "Header Font Family",
+          type: "string",
           options: {
             list: [
-              { title: 'Same as Body', value: 'inherit' },
-              { title: 'Inter', value: 'Inter, sans-serif' },
-              { title: 'Poppins', value: 'Poppins, sans-serif' },
-              { title: 'Roboto', value: 'Roboto, sans-serif' },
-              { title: 'Georgia', value: 'Georgia, serif' },
-              { title: 'Custom', value: 'custom' },
+              { title: "Same as Body", value: "inherit" },
+              { title: "Inter", value: "Inter, sans-serif" },
+              { title: "Poppins", value: "Poppins, sans-serif" },
+              { title: "Roboto", value: "Roboto, sans-serif" },
+              { title: "Georgia", value: "Georgia, serif" },
+              { title: "Custom", value: "custom" },
             ],
           },
         }),
         defineField({
-          name: 'customHeaderFontFamily',
-          title: 'Custom Header Font (optional)',
-          type: 'string',
-          hidden: ({ parent }) => !parent || parent.headerFontFamily !== 'custom',
+          name: "customHeaderFontFamily",
+          title: "Custom Header Font (optional)",
+          type: "string",
+          hidden: ({ parent }) =>
+            !parent || parent.headerFontFamily !== "custom",
         }),
 
         defineField({
-          name: 'baseFontSize',
-          title: 'Base Font Size (px)',
-          type: 'number',
+          name: "baseFontSize",
+          title: "Base Font Size (px)",
+          type: "number",
         }),
         defineField({
-          name: 'baseFontWeight',
-          title: 'Base Font Weight',
-          type: 'string',
+          name: "baseFontWeight",
+          title: "Base Font Weight",
+          type: "string",
           options: {
             list: [
-              { title: 'Light', value: '300' },
-              { title: 'Regular', value: '400' },
-              { title: 'Medium', value: '500' },
-              { title: 'Bold', value: '700' },
+              { title: "Light", value: "300" },
+              { title: "Regular", value: "400" },
+              { title: "Medium", value: "500" },
+              { title: "Bold", value: "700" },
             ],
           },
         }),
 
         // Headings
         defineField({
-          name: 'headings',
-          title: 'Headings',
-          type: 'object',
-          fields: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(tag =>
+          name: "headings",
+          title: "Headings",
+          type: "object",
+          fields: ["h1", "h2", "h3", "h4", "h5", "h6"].map((tag) =>
             defineField({
               name: tag,
               title: tag.toUpperCase(),
-              type: 'object',
+              type: "object",
               fields: [
-                defineField({ name: 'fontSize', title: 'Font Size (px)', type: 'number' }),
                 defineField({
-                  name: 'fontWeight',
-                  title: 'Font Weight',
-                  type: 'string',
+                  name: "fontSize",
+                  title: "Font Size (px)",
+                  type: "number",
+                }),
+                defineField({
+                  name: "fontWeight",
+                  title: "Font Weight",
+                  type: "string",
                   options: {
                     list: [
-                      { title: 'Light', value: '300' },
-                      { title: 'Regular', value: '400' },
-                      { title: 'Medium', value: '500' },
-                      { title: 'Bold', value: '700' },
-                      { title: 'Extra Bold', value: '800' },
+                      { title: "Light", value: "300" },
+                      { title: "Regular", value: "400" },
+                      { title: "Medium", value: "500" },
+                      { title: "Bold", value: "700" },
+                      { title: "Extra Bold", value: "800" },
                     ],
                   },
                 }),
-                defineField({ name: 'lineHeight', title: 'Line Height', type: 'number' }),
-                defineField({ name: 'letterSpacing', title: 'Letter Spacing (em)', type: 'number' }),
                 defineField({
-                  name: 'textTransform',
-                  title: 'Text Transform',
-                  type: 'string',
+                  name: "lineHeight",
+                  title: "Line Height",
+                  type: "number",
+                }),
+                defineField({
+                  name: "letterSpacing",
+                  title: "Letter Spacing (em)",
+                  type: "number",
+                }),
+                defineField({
+                  name: "textTransform",
+                  title: "Text Transform",
+                  type: "string",
                   options: {
                     list: [
-                      { title: 'None', value: 'none' },
-                      { title: 'Uppercase', value: 'uppercase' },
-                      { title: 'Lowercase', value: 'lowercase' },
-                      { title: 'Capitalize', value: 'capitalize' },
+                      { title: "None", value: "none" },
+                      { title: "Uppercase", value: "uppercase" },
+                      { title: "Lowercase", value: "lowercase" },
+                      { title: "Capitalize", value: "capitalize" },
                     ],
                   },
                 }),
               ],
-            })
+            }),
           ),
         }),
       ],
@@ -184,22 +217,30 @@ export default defineType({
 
     // Spacing
     defineField({
-      name: 'spacing',
-      title: 'Spacing & Radius',
-      type: 'object',
+      name: "spacing",
+      title: "Spacing & Radius",
+      type: "object",
       fields: [
-        defineField({ name: 'space', title: 'Base Spacing Unit (px)', type: 'number' }),
-        defineField({ name: 'borderRadius', title: 'Border Radius (px)', type: 'number' }),
-        defineField({ name: 'boxShadow', title: 'Box Shadow', type: 'string' }),
+        defineField({
+          name: "space",
+          title: "Base Spacing Unit (px)",
+          type: "number",
+        }),
+        defineField({
+          name: "borderRadius",
+          title: "Border Radius (px)",
+          type: "number",
+        }),
+        defineField({ name: "boxShadow", title: "Box Shadow", type: "string" }),
       ],
     }),
   ],
 
   preview: {
     select: {
-      title: 'themeName',
-      subtitle: 'mode',
-      media: 'logo'
+      title: "themeName",
+      subtitle: "mode",
+      media: "logo",
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
- extend designToken schema to support header and body colors
- update design token types and Tailwind config
- apply new CSS variables and update header/nav styles
- improve initial theme logic and home page layout

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: Process from config.webServer was not able to start)*
- `npm run lint` *(fails due to Prettier warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688d6d282c608332be9350eb9b5d8d06