### PR TITLE
fix: resolve refractor import errors by updating sanity packages

### DIFF
--- a/gregdchan/package-lock.json
+++ b/gregdchan/package-lock.json
@@ -9,19 +9,19 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/code-input": "^5.1.3",
-        "@sanity/color-input": "^4.0.5",
-        "@sanity/vision": "^4.2.0",
+        "@sanity/code-input": "^6.0.0",
+        "@sanity/color-input": "^4.0.6",
+        "@sanity/vision": "^4.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-is": "^19.1.1",
         "refractor": "^5.0.0",
-        "sanity": "^4.2.0",
+        "sanity": "^4.3.0",
         "styled-components": "^6.1.15"
       },
       "devDependencies": {
         "@sanity-codegen/cli": "^1.0.0-alpha.13",
-        "@sanity/codegen": "^3.95.0",
+        "@sanity/codegen": "^4.3.0",
         "@sanity/eslint-config-studio": "^5.0.1",
         "@types/react": "^18.0.25",
         "eslint": "^9.9.0",
@@ -2411,9 +2411,9 @@
       }
     },
     "node_modules/@date-fns/tz": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
-      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.3.1.tgz",
+      "integrity": "sha512-LnBOyuj+piItX/D5BWBSckBsuZyOt7Jg2obGNiObq7qjl1A2/8F+i4RS8/MmkSdnw6hOe6afrJLCWrUWZw5Mlw==",
       "license": "MIT"
     },
     "node_modules/@date-fns/utc": {
@@ -3288,14 +3288,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
-      "integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.16.tgz",
+      "integrity": "sha512-iSzLjT4C6YKp2DU0fr8T7a97FnRRxMO6CushJnW5ktxLNM2iNeuyUuUA5255eOLPORoGYCrVnuDOEBdGkHGkpw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "external-editor": "^3.1.0"
+        "@inquirer/external-editor": "^1.0.0",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -3329,6 +3329,22 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.0.tgz",
+      "integrity": "sha512-5v3YXc5ZMfL6OJqXPrX9csb4l7NlQA2doO1yynUjpUChT9hg4JcuBVP0RbsEJ/3SL/sxWEyFjT2W69ZhtoBWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
       }
     },
     "node_modules/@inquirer/figures": {
@@ -3405,14 +3421,14 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.0.tgz",
-      "integrity": "sha512-JHwGbQ6wjf1dxxnalDYpZwZxUEosT+6CPGD9Zh4sm9WXdtUp9XODCQD3NjSTmu+0OAyxWXNOqf0spjIymJa2Tw==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.1.tgz",
+      "integrity": "sha512-LpBPeIpyCF1H3C7SK/QxJQG4iV1/SRmJdymfcul8PuwtVhD0JI1CSwqmd83VgRgt1QEsDojQYFSXJSgo81PVMw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.2.0",
         "@inquirer/confirm": "^5.1.14",
-        "@inquirer/editor": "^4.2.15",
+        "@inquirer/editor": "^4.2.16",
         "@inquirer/expand": "^4.0.17",
         "@inquirer/input": "^4.2.1",
         "@inquirer/number": "^3.0.17",
@@ -4386,26 +4402,26 @@
       }
     },
     "node_modules/@portabletext/block-tools": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-2.0.0.tgz",
-      "integrity": "sha512-lpQWs7JXynBSJNJ5fU7COBMAKz1jpMvn4rTHwdWL7mEZgNMCvRFk667rmi9hGYmFwEsnJYfUZ07zVJbp5E30Aw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-2.0.8.tgz",
+      "integrity": "sha512-scqpOduDxMXZRNQIHO6g8oNy+SsndtEF1FdLuLiosdDf6LXvx3qM4ck0FOsts1Yf8v6fY8GmQ87O54DSMfnyMw==",
       "license": "MIT",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@sanity/types": "^4.0.1",
+        "@sanity/types": "^4.3.0",
         "@types/react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-2.0.0.tgz",
-      "integrity": "sha512-PotWWMElikv+oW087jYWh+V1Tx41t7r9cRb8o60oG6PFUcPPaWWV1djF8UqacTDwUh4NwO2FHJ1bXaSZS0lypQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-2.3.0.tgz",
+      "integrity": "sha512-OAmGsk1Qa+StFJtFbsCh+Lpzp/HYo6XZsbrziPOOgQZJy7iXWRk8N1RVZ4M5u6wEYtVx7wgqtS44Dd0GMeoVgg==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/block-tools": "2.0.0",
+        "@portabletext/block-tools": "2.0.8",
         "@portabletext/keyboard-shortcuts": "1.1.1",
         "@portabletext/patches": "1.1.6",
         "@portabletext/to-html": "^2.0.14",
@@ -4416,18 +4432,17 @@
         "lodash": "^4.17.21",
         "lodash.startcase": "^4.4.0",
         "react-compiler-runtime": "19.1.0-rc.2",
-        "slate": "0.117.2",
+        "slate": "0.118.0",
         "slate-dom": "^0.117.4",
         "slate-react": "0.117.4",
-        "use-effect-event": "^2.0.3",
-        "xstate": "^5.20.1"
+        "xstate": "^5.20.2"
       },
       "engines": {
         "node": ">=20.19"
       },
       "peerDependencies": {
-        "@sanity/schema": "^4.0.1",
-        "@sanity/types": "^4.0.1",
+        "@sanity/schema": "^4.3.0",
+        "@sanity/types": "^4.3.0",
         "react": "^18.3 || ^19",
         "rxjs": "^7.8.2"
       }
@@ -4943,20 +4958,20 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.2.0.tgz",
-      "integrity": "sha512-wzuNiRRP40hc0DyU4JAoJc5AyNjln8sDDcWWFp8OSzd0ydOZKR1SasVP6lRMEg2tXcQ4bVnGgo3kpXPm7UZjpQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.3.0.tgz",
+      "integrity": "sha512-nMhueHdotvt1mD5Se+/Qik4Cz9NyXm2TG865rPf9CfenBxouTG6OFYXNL8FVP9Bf2MUWdlpyTngRTNrrWYjE9w==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.0",
-        "@sanity/client": "^7.8.1",
-        "@sanity/codegen": "4.2.0",
-        "@sanity/runtime-cli": "^10.0.0",
+        "@sanity/client": "^7.8.2",
+        "@sanity/codegen": "4.3.0",
+        "@sanity/runtime-cli": "^10.1.2",
         "@sanity/telemetry": "^0.8.0",
         "@sanity/template-validator": "^2.4.3",
-        "@sanity/util": "4.2.0",
+        "@sanity/util": "4.3.0",
         "chalk": "^4.1.2",
-        "debug": "^4.3.4",
+        "debug": "^4.4.1",
         "decompress": "^4.2.0",
         "esbuild": "0.25.8",
         "esbuild-register": "^3.6.0",
@@ -4970,41 +4985,6 @@
       "bin": {
         "sanity": "bin/sanity"
       },
-      "engines": {
-        "node": ">=20.19"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/@sanity/codegen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.2.0.tgz",
-      "integrity": "sha512-9teuISUQwoEZ8FgZI+vQAikk6bkyYwEYzu294X7AU1DyyI8oS8Y/hJNESZIq/eWM10XTY91J/zsd+2O16L23mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/generator": "^7.28.0",
-        "@babel/preset-env": "^7.28.0",
-        "@babel/preset-react": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "@babel/register": "^7.27.1",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "groq": "4.2.0",
-        "groq-js": "^1.17.3",
-        "json5": "^2.2.3",
-        "tsconfig-paths": "^4.2.0",
-        "zod": "^3.25.76"
-      },
-      "engines": {
-        "node": ">=20.19"
-      }
-    },
-    "node_modules/@sanity/cli/node_modules/groq": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-4.2.0.tgz",
-      "integrity": "sha512-bHpqjCbESfVvJO3CbkSgg9jh9s8vM5np6SvcDuXC6ckIhPCkRXwnEnDGG/6CeoV5RMf9v9XR4HyhC9KTFsE0Rg==",
-      "license": "MIT",
       "engines": {
         "node": ">=20.19"
       }
@@ -5046,9 +5026,9 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.8.1.tgz",
-      "integrity": "sha512-jz/IizNHGrss7BG+wFzhI2l2f2avayM4dsBcxKRW4T3HSP4MP7T3oA6vgSDRX1N6KfQfFVILNq6bBE0ut8cHUA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.8.2.tgz",
+      "integrity": "sha512-Me3/eh71VFdbSHghuea80rcDQZir/NgtwANKug/mPbbwwENYASJSEHpAy2VZwn4FyHHIR9d2pNRIyXMzGab+dQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -5061,9 +5041,9 @@
       }
     },
     "node_modules/@sanity/code-input": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-5.1.3.tgz",
-      "integrity": "sha512-KFAKULQNEPOI2AoY26rhDwZKeD5iTSyaQdQO6ZbjJybD6VJt3reHuaFsQC3t/6zd4r0lPdwuSEmPA2WXzwQwaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-6.0.0.tgz",
+      "integrity": "sha512-5VLZSPKz6RDMFRK7HWDSiSljtlFKbx2cGSkXF6sYleqbvaUrzygLK+Y7S2bWuhYidpej4lWeNJ9CMHDjRtLp1w==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -5084,12 +5064,12 @@
         "@lezer/highlight": "^1.2.1",
         "@sanity/icons": "^3.5.2",
         "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "^2.10.9",
+        "@sanity/ui": "^3.0.5",
         "@uiw/codemirror-themes": "^4.23.6",
         "@uiw/react-codemirror": "^4.23.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19 >=22.12.0"
       },
       "peerDependencies": {
         "react": "^18 || >=19.0.0-0",
@@ -5099,10 +5079,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.99.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.99.0.tgz",
-      "integrity": "sha512-XTI6X6uFCms7PLHtCXNTLIoAbR5Mjg5yPrEn3EhHlGyNJV6CSyEOUtd+KyjrAQzC0FQPvT5aZJF1x5hVX+Cwdw==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.3.0.tgz",
+      "integrity": "sha512-c9SpcR3l7C1FR+03fq4A+5r+A5nGpSBy+FAqQZMgK6cpaLtMcm9CIqMYKnVQ2Nmb6PRpYztALfLRl9CMDfF1LQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -5112,24 +5091,23 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/register": "^7.27.1",
         "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "debug": "^4.3.4",
+        "@babel/types": "^7.28.2",
+        "debug": "^4.4.1",
         "globby": "^11.1.0",
-        "groq": "3.99.0",
-        "groq-js": "^1.17.1",
+        "groq": "4.3.0",
+        "groq-js": "^1.17.3",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
-        "zod": "^3.22.4"
+        "zod": "^3.25.76"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19"
       }
     },
     "node_modules/@sanity/codegen/node_modules/groq-js": {
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.17.3.tgz",
       "integrity": "sha512-Z6/n5Ro246RlntMoZKTIjB3GDCFcs8NLCkIrI8AbS1Ho7yVAtNQqxxJd2W4ENk9+a03gTQYtunNGlcHJM9hhQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -5148,14 +5126,14 @@
       }
     },
     "node_modules/@sanity/color-input": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/color-input/-/color-input-4.0.5.tgz",
-      "integrity": "sha512-ITW+vIWoUEM3wFHJiuf2+2m6EiFh1DWULm1xcuvg7bIbtzibS93B0M7dtwJ4dZnUao2aN+bhNVh4TtKTux13iQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@sanity/color-input/-/color-input-4.0.6.tgz",
+      "integrity": "sha512-ffj9EyJHDTUpwPLa5VUaStH3Db/zYJaHajWWwyY4ILzfbDGIMekyC1gVYbeB2OvHgc9p9TkwIOsRBFY71o+U9Q==",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^3.5.3",
         "@sanity/incompatible-plugin": "^1.0.5",
-        "@sanity/ui": "^2.10.10",
+        "@sanity/ui": "^3.0.5",
         "react-color": "^2.19.3",
         "use-effect-event": "^2.0.3"
       },
@@ -5169,9 +5147,9 @@
       }
     },
     "node_modules/@sanity/comlink": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.8.tgz",
-      "integrity": "sha512-HcbOu6GkR936eOS8ezo7ext5aSp5SKH3d8fxRWrZCJU9ZejZYPb3gnZ3PW9uUp1NYh5RnMXBsUDpE1IJtpjA9g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.9.tgz",
+      "integrity": "sha512-eF6dC1tolwhSn7x479ODSyQkSiaEDIMzL7urprzxURKfzDKqJIA8S0wexhAx53gHCF6/Odh/2IpMxf/n78U+QQ==",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
@@ -5208,9 +5186,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.2.0.tgz",
-      "integrity": "sha512-T+FJAFjek3jpZZ15WP8Q0OToNCWxv/HfGgseOonQx9B0RuGEMSjEnP62N1xh5nnzEp3RhuNXpdrfgw37OTqpWw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.3.0.tgz",
+      "integrity": "sha512-ENxYuxRk/wr1h8aFrzpUtVI6UR6FtWNzTAn9HTMgAU1tppVJreshpv28Ia7LASky6cMg7uU/N6Cwcs+tLr3gMg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -5653,9 +5631,9 @@
       }
     },
     "node_modules/@sanity/insert-menu": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-2.0.0.tgz",
-      "integrity": "sha512-OsKXN2T/LmYG+4u/iooNp1vIwkHKsVN0kTGUhM55hA8vntvCba933XwmJgmZlymYePTn02P7kxD+92lZP06JMg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-2.0.1.tgz",
+      "integrity": "sha512-PBHua3RJ+YAH71YJwDgh31XROoytl28jipaJk3H2i9Btt0GwzpyaCKaqRTNWsf4k+dQ4HMFw1URrtt4WCCQTPw==",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^3.7.4",
@@ -5672,105 +5650,6 @@
         "react-dom": "^18.3 || >=19.0.0-rc",
         "react-is": "^18.3 || >=19.0.0-rc"
       }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/@sanity/ui": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.0.5.tgz",
-      "integrity": "sha512-TnE4FM1ROn1cq6lywJDqdYpRVhGyKXT2K8a4jFpycgX90HXg5yLMBxuzZwnzRCJr/oB+NOevWZGZZY1fSlDTKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.5",
-        "@juggle/resize-observer": "^3.4.0",
-        "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.4",
-        "csstype": "^3.1.3",
-        "framer-motion": "^12.23.12",
-        "react-compiler-runtime": "19.1.0-rc.2",
-        "react-refractor": "^4.0.0",
-        "use-effect-event": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "peerDependencies": {
-        "react": "^18 || >=19.0.0-0",
-        "react-dom": "^18 || >=19.0.0-0",
-        "react-is": "^18 || >=19.0.0-0",
-        "styled-components": "^5.2 || ^6"
-      }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/react-refractor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-4.0.0.tgz",
-      "integrity": "sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==",
-      "license": "MIT",
-      "dependencies": {
-        "refractor": "^5.0.0",
-        "unist-util-filter": "^5.0.1",
-        "unist-util-visit-parents": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0"
-      }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-filter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
-      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-filter/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-is/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/unist-util-visit-parents/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
     },
     "node_modules/@sanity/json-match": {
       "version": "1.0.5",
@@ -5813,17 +5692,17 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.2.0.tgz",
-      "integrity": "sha512-qzdmgGRV6VLVeuoKvtllcGadBJS+tGq/WC/lp4CrnRqzhEpOv+9XbAcwrVIYpLSYArrWF4wPEElWDMneNchQiQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.3.0.tgz",
+      "integrity": "sha512-X56FECR4jPVibxFUcYoC4a2rO0zgsckQLnQC+t/IRfMJBDewQcEpFvTeC07R8PQkgOfBzYKabNALHDgWP+wIyg==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.8.1",
+        "@sanity/client": "^7.8.2",
         "@sanity/mutate": "^0.12.4",
-        "@sanity/types": "4.2.0",
-        "@sanity/util": "4.2.0",
+        "@sanity/types": "4.3.0",
+        "@sanity/util": "4.3.0",
         "arrify": "^2.0.1",
-        "debug": "^4.3.4",
+        "debug": "^4.4.1",
         "fast-fifo": "^1.3.2",
         "groq-js": "^1.17.3",
         "p-map": "^7.0.1"
@@ -5896,32 +5775,32 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.2.0.tgz",
-      "integrity": "sha512-moEVBsjYT3Q4+SqCF5AaCuSOgRA+R2xzp+ESi/hzJcnI3r7qdTWPEB4zF9aSz30mEwQI9lZWKK21Fz0WJhW+Ww==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.3.0.tgz",
+      "integrity": "sha512-5cYQxPlHlQjX0m2gm8cS5zFZH8NdMJdYVeSLAg56FxG7oiojVX2nZE/831F1Ns7DgS6ltd/3xhLMv2zeITx4NQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "4.2.0",
+        "@sanity/types": "4.3.0",
         "@sanity/uuid": "^3.0.2",
-        "debug": "^4.3.4",
+        "debug": "^4.4.1",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/presentation-comlink": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.26.tgz",
-      "integrity": "sha512-3HZv1Vt4SatGkLgAo3Nwm1flWe/DCvw1JfBf9+o5xHUfFhFGEGc1WmoszxaXLXmCY7LhfIszoMFNn44sWhCrYw==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.28.tgz",
+      "integrity": "sha512-3LqQQ9MZy4Vut65XYsW0mPFF3gdv/8OKQy3m7zuSIc1HkQNbSLqbD+o7KaBfDnpXQxfk6HXS2zJyrJRO87us1A==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/comlink": "^3.0.8",
-        "@sanity/visual-editing-types": "^1.1.4"
+        "@sanity/comlink": "^3.0.9",
+        "@sanity/visual-editing-types": "^1.1.5"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.8.1"
+        "@sanity/client": "^7.8.2"
       }
     },
     "node_modules/@sanity/preview-url-secret": {
@@ -6000,9 +5879,9 @@
       }
     },
     "node_modules/@sanity/runtime-cli/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
+      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -6437,14 +6316,14 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.2.0.tgz",
-      "integrity": "sha512-ou9oAlM5a2dAbdbf62fkzAnZxobcfSYMpHLdU+QDRxT2HED2EsMI8NGNI1p2NN02VZnL4xQVYP47DkPct2KycA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.3.0.tgz",
+      "integrity": "sha512-mnz/q6eNw28lpPJf6YaCNVaIDy2ZFn/NRpEU7v7euCn6Pzkybmi5pzvKC1Q+Shd/5HcPkhFtHVDziTqkH3AjWg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/descriptors": "^1.1.1",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "4.2.0",
+        "@sanity/types": "4.3.0",
         "arrify": "^2.0.1",
         "groq-js": "^1.17.3",
         "humanize-list": "^1.0.1",
@@ -6605,12 +6484,12 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-BLRafZXQ7r8jq7j8ehf7a8M/wD7zenEtLIFOdA24JhOGiIGqd19HnxejrREnJL4mLWPnVwE77StHXHC8DRiurA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-QoY+8VgPK0bbTSmnhlcRUxzLhudb78ICaqRXMCMzmoR8IUoXUQaSydEW83Ar1WsG/HL0c61flJqFboRbffa6Vw==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.8.1",
+        "@sanity/client": "^7.8.2",
         "@sanity/media-library-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -6618,9 +6497,9 @@
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "2.16.12",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.16.12.tgz",
-      "integrity": "sha512-aAlsoYPM2MyvhsUKCvYvQ65oFFQH4KktB4crN0JL81qu915XKSYoXF/E2rge8EJCjaml18X3zFJLmwuP+XaCsw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.0.6.tgz",
+      "integrity": "sha512-v2lr8FO40hGR/03dyMdKazMHuqs8uGTXra92I0CJcmoIIFlI3XPZbLaz8Lpb+lKWDFipkvZLnnB2Muf1e9vR+A==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.5",
@@ -6630,11 +6509,11 @@
         "csstype": "^3.1.3",
         "framer-motion": "^12.23.12",
         "react-compiler-runtime": "19.1.0-rc.2",
-        "react-refractor": "^2.2.0",
+        "react-refractor": "^4.0.0",
         "use-effect-event": "^2.0.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19 >=22.12.0"
       },
       "peerDependencies": {
         "react": "^18 || >=19.0.0-0",
@@ -6644,15 +6523,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.2.0.tgz",
-      "integrity": "sha512-h3UF6QgqXsit0BlqzClvz6L1Y+8VGqmgbI1FZCsU8QNNQnn11sTd0u5ZrE0KLxpPjqhYitJcOvmk2STGmHZj7g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.3.0.tgz",
+      "integrity": "sha512-WwZkfN98kyKOaaxNMkKLuelX5LmB1iUFVDNpDLOYEheg7gXs3ayUsVkIc6RXSMlomohpUMjw+cd0n4psugMy5A==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.2.0",
         "@date-fns/utc": "^2.1.0",
-        "@sanity/client": "^7.8.1",
-        "@sanity/types": "4.2.0",
+        "@sanity/client": "^7.8.2",
+        "@sanity/types": "4.3.0",
         "date-fns": "^4.1.0",
         "get-random-values-esm": "1.0.2",
         "rxjs": "^7.8.2"
@@ -6682,25 +6561,25 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.2.0.tgz",
-      "integrity": "sha512-pHybE99Z04QDvSaBm4+wr+sdzJG9n0r2T10MnpnzjW396C9+PHUppO02v/dMNnjje9UvFxMlKebrLZTfraHsvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.3.0.tgz",
+      "integrity": "sha512-PWCjTrlb9TEd7Z2UYqSB860jdWrS9YsMgvt06UL0wdPyquQXoPMtytDux4psn3laCUS/G/7xXcNnxJssaITcZw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.8.1",
         "@codemirror/lang-javascript": "^6.2.4",
-        "@codemirror/language": "^6.11.1",
+        "@codemirror/language": "^6.11.2",
         "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.37.2",
+        "@codemirror/view": "^6.38.1",
         "@juggle/resize-observer": "^3.4.0",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@rexxars/react-split-pane": "^1.0.0",
         "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.7.4",
-        "@sanity/ui": "^3.0.1",
+        "@sanity/ui": "^3.0.5",
         "@sanity/uuid": "^3.0.2",
         "@uiw/react-codemirror": "^4.24.1",
         "is-hotkey-esm": "^1.0.0",
@@ -6729,109 +6608,10 @@
         "react-dom": "^18 || ^19"
       }
     },
-    "node_modules/@sanity/vision/node_modules/@sanity/ui": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.0.5.tgz",
-      "integrity": "sha512-TnE4FM1ROn1cq6lywJDqdYpRVhGyKXT2K8a4jFpycgX90HXg5yLMBxuzZwnzRCJr/oB+NOevWZGZZY1fSlDTKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.5",
-        "@juggle/resize-observer": "^3.4.0",
-        "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.4",
-        "csstype": "^3.1.3",
-        "framer-motion": "^12.23.12",
-        "react-compiler-runtime": "19.1.0-rc.2",
-        "react-refractor": "^4.0.0",
-        "use-effect-event": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "peerDependencies": {
-        "react": "^18 || >=19.0.0-0",
-        "react-dom": "^18 || >=19.0.0-0",
-        "react-is": "^18 || >=19.0.0-0",
-        "styled-components": "^5.2 || ^6"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/react-refractor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-4.0.0.tgz",
-      "integrity": "sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==",
-      "license": "MIT",
-      "dependencies": {
-        "refractor": "^5.0.0",
-        "unist-util-filter": "^5.0.1",
-        "unist-util-visit-parents": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-filter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
-      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-filter/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-is/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@sanity/vision/node_modules/unist-util-visit-parents/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
     "node_modules/@sanity/visual-editing-types": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.4.tgz",
-      "integrity": "sha512-ARy2IsHWQm/rj+8q/NqcPR3IFILztI3Nfdw0INOSSXCA56pVMYXNApYY9DzZr5Do6KgQCsUa2QpammwtoIu/ug==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.5.tgz",
+      "integrity": "sha512-jDQyO59R9TG7QC6XQ5n8PVWCVRdebez1ws9d8j1HVmPzjIhWRkyQbA/xrfrtYDPo/vuVD8wUbkXOh1TScITVXQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8308,6 +8088,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8632,9 +8413,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "license": "MIT"
     },
     "node_modules/chokidar": {
@@ -8922,6 +8703,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -10615,20 +10397,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11648,13 +11416,12 @@
       "license": "MIT"
     },
     "node_modules/groq": {
-      "version": "3.99.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.99.0.tgz",
-      "integrity": "sha512-ZwKAWzvVCw51yjmIf5484KgsAzZAlGTM4uy9lki4PjAYxcEME2Xf93d31LhHzgUAr2JI79H+cNKoRjDHdv1BXQ==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-4.3.0.tgz",
+      "integrity": "sha512-DVlxad9N9vY+7h8hPo+WKDpIKtJO2XBmg6ZyJBqr4A3BLVx4SJhenTuPU18YzLqn7+ceOsIPw0RMMyD4mD04Pw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19"
       }
     },
     "node_modules/groq-js": {
@@ -12007,12 +11774,12 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -12127,13 +11894,13 @@
       "license": "ISC"
     },
     "node_modules/inquirer": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.0.tgz",
-      "integrity": "sha512-LlFVmvWVCun7uEgPB3vups9NzBrjJn48kRNtFGw3xU1H5UXExTEz/oF1JGLaB0fvlkUB+W6JfgLcSEaSdH7RPA==",
+      "version": "12.9.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.1.tgz",
+      "integrity": "sha512-G7uXAb9OiLcd+9jmA/7KKrItvFF00kKk/jb6CtG+Tm2zSPWfzzhyJwDhVCy+mBmE32o2zJnB5JnknIIv2Ft+AA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.15",
-        "@inquirer/prompts": "^7.8.0",
+        "@inquirer/prompts": "^7.8.1",
         "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "mute-stream": "^2.0.0",
@@ -12917,15 +12684,14 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
+        "async": "^3.2.6",
         "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -13625,6 +13391,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14133,15 +13900,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -14980,15 +14738,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -15304,193 +15053,20 @@
       "license": "MIT"
     },
     "node_modules/react-refractor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-2.2.0.tgz",
-      "integrity": "sha512-UvWkBVqH/2b9nkkkt4UNFtU3aY1orQfd4plPjx5rxbefy6vGajNHU9n+tv8CbykFyVirr3vEBfN2JTxyK0d36g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-4.0.0.tgz",
+      "integrity": "sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==",
       "license": "MIT",
       "dependencies": {
-        "refractor": "^3.6.0",
-        "unist-util-filter": "^2.0.2",
-        "unist-util-visit-parents": "^3.0.2"
+        "refractor": "^5.0.0",
+        "unist-util-filter": "^5.0.1",
+        "unist-util-visit-parents": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
-    "node_modules/react-refractor/node_modules/@types/hast": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
-      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2"
-      }
-    },
-    "node_modules/react-refractor/node_modules/character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/comma-separated-tokens": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/hast-util-parse-selector": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-refractor/node_modules/hastscript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
-      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-refractor/node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/property-information": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/refractor": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
-      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
-      "license": "MIT",
-      "dependencies": {
-        "hastscript": "^6.0.0",
-        "parse-entities": "^2.0.0",
-        "prismjs": "~1.27.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-refractor/node_modules/space-separated-tokens": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+        "react": ">=18.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -16064,9 +15640,9 @@
       "license": "MIT"
     },
     "node_modules/run-async": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
-      "integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -16247,9 +15823,9 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.2.0.tgz",
-      "integrity": "sha512-NEViKRlWnpix1Yla1d5B5TGKMsTDQIb68BwYNRdc9jbWtvpzPKexUlomqwYQsYYB8PYaDIii9zVL5z6Kjjhutg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.3.0.tgz",
+      "integrity": "sha512-UQd0NuU4D6ybEebpUiGh1T2r/Qoi7P/fw6mVixl7tupzuRF7V7pBsrzyKiASx2izj2CVE89dbZaEdA6rH5JkjQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -16258,18 +15834,18 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@juggle/resize-observer": "^3.4.0",
         "@mux/mux-player-react": "^3.5.1",
-        "@portabletext/block-tools": "^2.0.0",
-        "@portabletext/editor": "^2.0.0",
+        "@portabletext/block-tools": "^2.0.5",
+        "@portabletext/editor": "^2.1.7",
         "@portabletext/react": "^3.2.1",
         "@portabletext/toolkit": "^2.0.17",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.2.1",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "4.2.0",
-        "@sanity/client": "^7.8.1",
+        "@sanity/cli": "4.3.0",
+        "@sanity/client": "^7.8.2",
         "@sanity/color": "^3.0.6",
-        "@sanity/comlink": "^3.0.8",
-        "@sanity/diff": "4.2.0",
+        "@sanity/comlink": "^3.0.9",
+        "@sanity/diff": "4.3.0",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
@@ -16278,24 +15854,24 @@
         "@sanity/id-utils": "^1.0.0",
         "@sanity/image-url": "^1.1.0",
         "@sanity/import": "^3.38.3",
-        "@sanity/insert-menu": "^2.0.0",
+        "@sanity/insert-menu": "^2.0.1",
         "@sanity/logos": "^2.2.1",
         "@sanity/media-library-types": "^1.0.0",
         "@sanity/message-protocol": "^0.15.1",
-        "@sanity/migrate": "4.2.0",
-        "@sanity/mutator": "4.2.0",
-        "@sanity/presentation-comlink": "^1.0.26",
+        "@sanity/migrate": "4.3.0",
+        "@sanity/mutator": "4.3.0",
+        "@sanity/presentation-comlink": "^1.0.27",
         "@sanity/preview-url-secret": "^2.1.14",
-        "@sanity/schema": "4.2.0",
+        "@sanity/schema": "4.3.0",
         "@sanity/sdk": "2.1.1",
         "@sanity/telemetry": "^0.8.0",
-        "@sanity/types": "4.2.0",
-        "@sanity/ui": "^3.0.1",
-        "@sanity/util": "4.2.0",
+        "@sanity/types": "4.3.0",
+        "@sanity/ui": "^3.0.5",
+        "@sanity/util": "4.3.0",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "^3.13.11",
+        "@tanstack/react-virtual": "^3.13.12",
         "@types/react-is": "^19.0.0",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
@@ -16315,14 +15891,14 @@
         "console-table-printer": "^2.11.1",
         "dataloader": "^2.2.3",
         "date-fns": "^2.30.0",
-        "debug": "^4.3.4",
+        "debug": "^4.4.1",
         "esbuild": "0.25.8",
         "esbuild-register": "^3.6.0",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
         "fast-deep-equal": "3.1.3",
         "form-data": "^4.0.0",
-        "framer-motion": "^12.23.6",
+        "framer-motion": "^12.23.12",
         "get-it": "^8.6.10",
         "get-random-values-esm": "1.0.2",
         "groq-js": "^1.17.3",
@@ -16354,7 +15930,7 @@
         "pirates": "^4.0.0",
         "player.style": "^0.1.9",
         "pluralize-esm": "^9.0.2",
-        "polished": "^4.2.2",
+        "polished": "^4.3.1",
         "preferred-pm": "^4.1.1",
         "pretty-ms": "^7.0.1",
         "quick-lru": "^5.1.1",
@@ -16363,7 +15939,7 @@
         "react-fast-compare": "^3.2.2",
         "react-focus-lock": "^2.13.6",
         "react-i18next": "15.6.1",
-        "react-is": "^18.2.0",
+        "react-is": "^19.1.1",
         "react-refractor": "^4.0.0",
         "react-rx": "^4.1.31",
         "read-pkg-up": "^7.0.1",
@@ -16371,7 +15947,6 @@
         "resolve-from": "^5.0.0",
         "resolve.exports": "^2.0.2",
         "rimraf": "^5.0.10",
-        "rollup": "4.45.3",
         "rxjs": "^7.8.2",
         "rxjs-exhaustmap-with-trailing": "^2.1.1",
         "rxjs-mergemap-array": "^0.1.0",
@@ -16404,32 +15979,6 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "styled-components": "^6.1.15"
-      }
-    },
-    "node_modules/sanity/node_modules/@sanity/ui": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.0.5.tgz",
-      "integrity": "sha512-TnE4FM1ROn1cq6lywJDqdYpRVhGyKXT2K8a4jFpycgX90HXg5yLMBxuzZwnzRCJr/oB+NOevWZGZZY1fSlDTKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.5",
-        "@juggle/resize-observer": "^3.4.0",
-        "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.4",
-        "csstype": "^3.1.3",
-        "framer-motion": "^12.23.12",
-        "react-compiler-runtime": "19.1.0-rc.2",
-        "react-refractor": "^4.0.0",
-        "use-effect-event": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "peerDependencies": {
-        "react": "^18 || >=19.0.0-0",
-        "react-dom": "^18 || >=19.0.0-0",
-        "react-is": "^18 || >=19.0.0-0",
-        "styled-components": "^5.2 || ^6"
       }
     },
     "node_modules/sanity/node_modules/@vitejs/plugin-react": {
@@ -16598,29 +16147,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/sanity/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/sanity/node_modules/react-refractor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-4.0.0.tgz",
-      "integrity": "sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==",
-      "license": "MIT",
-      "dependencies": {
-        "refractor": "^5.0.0",
-        "unist-util-filter": "^5.0.1",
-        "unist-util-visit-parents": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0"
-      }
-    },
     "node_modules/sanity/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -16653,62 +16179,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/sanity/node_modules/unist-util-filter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
-      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      }
-    },
-    "node_modules/sanity/node_modules/unist-util-filter/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/sanity/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/sanity/node_modules/unist-util-is/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/sanity/node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/sanity/node_modules/unist-util-visit-parents/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
     },
     "node_modules/sanity/node_modules/uuid": {
       "version": "11.1.0",
@@ -17086,9 +16556,9 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.117.2",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.117.2.tgz",
-      "integrity": "sha512-vHfMHrb8WJ6TFfl7yLXT+UlTzdbUQHpAfdGV0tJfECvbRMAOwAKkjgtAMI8FBmJ1t6BKUgX3ybXk3Y2JxQ2R1w==",
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.118.0.tgz",
+      "integrity": "sha512-XAHgaoN3IikTz83DlJWZWR7e4SjuRn1Ps6I717fL7yaITF7zhZm5z8zbU+TaPlHu4APCV6TCMIF33EZdW3GqfQ==",
       "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
@@ -17809,18 +17279,6 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "license": "MIT"
     },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/to-buffer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
@@ -18248,37 +17706,60 @@
       }
     },
     "node_modules/unist-util-filter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-2.0.3.tgz",
-      "integrity": "sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
       "license": "MIT",
       "dependencies": {
-        "unist-util-is": "^4.0.0"
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       }
+    },
+    "node_modules/unist-util-filter/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "license": "MIT",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
+        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -18543,18 +18024,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -18833,9 +18302,9 @@
       }
     },
     "node_modules/xstate": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.20.1.tgz",
-      "integrity": "sha512-i9ZpNnm/XhCOMUxae1suT8PjYNTStZWbhmuKt4xeTPaYG5TS0Fz0i+Ka5yxoNPpaHW3VW6JIowrwFgSTZONxig==",
+      "version": "5.20.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.20.2.tgz",
+      "integrity": "sha512-GZmLmc+WPKfFRxuTDAxCg0cUhS/ZnWaRD86DO8MKizeK4a050jd5k7UNnIQ2jJDWRig2/r0tmVXeezUNIhoz5Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/gregdchan/package.json
+++ b/gregdchan/package.json
@@ -12,19 +12,19 @@
     "gen:types": "sanity-codegen schema-codegen"
   },
   "dependencies": {
-    "@sanity/code-input": "^5.1.3",
-    "@sanity/color-input": "^4.0.5",
-    "@sanity/vision": "^4.2.0",
+    "@sanity/code-input": "^6.0.0",
+    "@sanity/color-input": "^4.0.6",
+    "@sanity/vision": "^4.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-is": "^19.1.1",
     "refractor": "^5.0.0",
-    "sanity": "^4.2.0",
+    "sanity": "^4.3.0",
     "styled-components": "^6.1.15"
   },
   "devDependencies": {
     "@sanity-codegen/cli": "^1.0.0-alpha.13",
-    "@sanity/codegen": "^3.95.0",
+    "@sanity/codegen": "^4.3.0",
     "@sanity/eslint-config-studio": "^5.0.1",
     "@types/react": "^18.0.25",
     "eslint": "^9.9.0",

--- a/gregdchan/sanity.config.ts
+++ b/gregdchan/sanity.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'sanity'
 import { structureTool } from 'sanity/structure'
 import { colorInput } from '@sanity/color-input'
+import { codeInput } from '@sanity/code-input'
 import schemaTypes from './schemas' // 👈 index.js or index.ts for schemas
 
 export default defineConfig({
@@ -13,7 +14,8 @@ export default defineConfig({
   // Sanity v3+ plugins
   plugins: [
     structureTool(), // Replaces deprecated deskTool()
-    colorInput()
+    colorInput(),
+    codeInput()
   ],
 
   schema: {


### PR DESCRIPTION
## Summary
- upgrade sanity, vision and code-input packages
- register `codeInput` plugin in studio config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch remote version)*

------
https://chatgpt.com/codex/tasks/task_e_6897f87e9310833283aa3aa8b0152b06