### PR TITLE
Fix header logo and theme toggle persistence

### DIFF
--- a/frontend/src/lib/Header.svelte
+++ b/frontend/src/lib/Header.svelte
@@ -1,52 +1,61 @@
 <script lang="ts">
-	import type { Navigation, NavItem } from '$lib/types/navigation';
-	export let navigation: Navigation | null;
-	export let logoUrl: string | null = null;
+        import ThemeToggle from '$lib/ThemeToggle.svelte';
+        import type { Navigation, NavItem } from '$lib/types/navigation';
+        export let navigation: Navigation | null;
+        export let logoUrl: string | null = null;
+        export let currentTheme: 'light' | 'dark' = 'light';
 
-	let resolvedLogoUrl = '';
-	$: if (!resolvedLogoUrl && logoUrl) resolvedLogoUrl = logoUrl;
+        let resolvedLogoUrl = '';
+        $: if (!resolvedLogoUrl && logoUrl) resolvedLogoUrl = logoUrl;
 
-	function href(item: NavItem) {
-		if (typeof item.link === 'string') return item.link;
-		if (item.link?.external) return item.link.external;
-		const slug = item.link?.internal?.slug?.current;
-		return slug ? `/${slug}` : '#';
-	}
+        function href(item: NavItem) {
+                if (typeof item.link === 'string') return item.link;
+                if (item.link?.external) return item.link.external;
+                const slug = item.link?.internal?.slug?.current;
+                return slug ? `/${slug}` : '#';
+        }
+
+        function handleThemeChange(event: CustomEvent<'light' | 'dark'>) {
+                currentTheme = event.detail;
+        }
 </script>
 
 <header class="bg-header text-header border-b">
 	<nav class="site-container w-full">
-		<div class="flex h-16 items-center justify-between">
-			<a href="/" aria-label="Home" class="flex items-center space-x-2">
-				{#if resolvedLogoUrl}
-					<img
-						src={resolvedLogoUrl}
-						alt="Site Logo"
-						width="160"
-						height="40"
-						decoding="async"
-						loading="eager"
-						fetchpriority="high"
-						style="display:block"
-					/>
-				{:else}
-					<span class="text-xl font-bold">Greg D. Chan</span>
-				{/if}
-			</a>
+                <div class="flex h-16 items-center justify-between">
+                        <a href="/" aria-label="Home" class="flex items-center space-x-2">
+                                {#if resolvedLogoUrl}
+                                        <img
+                                                src={resolvedLogoUrl}
+                                                alt="Site Logo"
+                                                width="160"
+                                                height="40"
+                                                decoding="async"
+                                                loading="eager"
+                                                fetchpriority="high"
+                                                style="display:block"
+                                        />
+                                {:else}
+                                        <span class="text-xl font-bold">Greg D. Chan</span>
+                                {/if}
+                        </a>
 
-			{#if navigation?.items}
-				<div class="hidden items-baseline space-x-4 md:flex">
-					{#each navigation.items as item}
-						<a
-							href={href(item)}
-							class="hover:text-primary px-3 py-2 text-sm"
-							target={item.target || '_self'}
-						>
-							{item.text}
-						</a>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	</nav>
+                        <div class="flex items-center space-x-4">
+                                {#if navigation?.items}
+                                        <div class="hidden items-baseline space-x-4 md:flex">
+                                                {#each navigation.items as item}
+                                                        <a
+                                                                href={href(item)}
+                                                                class="hover:text-primary px-3 py-2 text-sm"
+                                                                target={item.target || '_self'}
+                                                        >
+                                                                {item.text}
+                                                        </a>
+                                                {/each}
+                                        </div>
+                                {/if}
+                                <ThemeToggle {currentTheme} on:themeChange={handleThemeChange} />
+                        </div>
+                </div>
+        </nav>
 </header>

--- a/frontend/src/lib/ThemeToggle.svelte
+++ b/frontend/src/lib/ThemeToggle.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { theme, toggleTheme } from '$lib/stores/themeStore';
-  
+  import { createEventDispatcher } from 'svelte';
+
   // No need for prop if using the store directly, but keep for compatibility
   export let currentTheme: 'light' | 'dark' = $theme;
+  const dispatch = createEventDispatcher<{ themeChange: 'light' | 'dark' }>();
+
+  function handleClick() {
+    const newTheme = $theme === 'dark' ? 'light' : 'dark';
+    toggleTheme();
+    dispatch('themeChange', newTheme);
+  }
 </script>
 
-<button 
-  on:click={toggleTheme}
+<button
+  on:click={handleClick}
   class="p-2 rounded-full bg-muted hover:bg-muted/80 transition-colors"
   aria-label={$theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
 >

--- a/frontend/src/lib/sanity/client.ts
+++ b/frontend/src/lib/sanity/client.ts
@@ -2,55 +2,29 @@ import { createClient } from '@sanity/client';
 import imageUrlBuilder from '@sanity/image-url';
 import type { DesignToken } from '$lib/types/designToken';
 import type { Navigation } from '$lib/types/navigation';
-import { LOGO_QUERY } from './queries';
+import { TOKEN_QUERY, NAV_QUERY, LOGO_QUERY } from './queries';
 
 export const sanity = createClient({
-	projectId: 'smxz6rsz',
-	dataset: 'production',
-	apiVersion: '2024-01-01',
-	useCdn: process.env.NODE_ENV === 'production'
+        projectId: 'smxz6rsz',
+        dataset: 'production',
+        apiVersion: '2024-01-01',
+        useCdn: process.env.NODE_ENV === 'production'
 });
 
+const builder = imageUrlBuilder(sanity);
+
 export async function fetchTokens(): Promise<{
-	light: DesignToken | null;
-	dark: DesignToken | null;
+        light: DesignToken | null;
+        dark: DesignToken | null;
 }> {
-	const query = `{
-    "light": *[_type == "designToken" && mode == "light" && isDefault == true][0],
-    "dark": *[_type == "designToken" && mode == "dark" && isDefault == true][0]
-  }`;
-	return await sanity.fetch(query);
+        return await sanity.fetch(TOKEN_QUERY);
 }
 
 export async function fetchNav(): Promise<Navigation | null> {
-	const query = `*[_type == "navigation" && slug.current == "main-menu"][0]{
-    items[]{
-      text,
-      link{
-        external,
-        internal->{
-          slug
-        }
-      },
-      target,
-      children[]{
-        text,
-        link{
-          external,
-          internal->{
-            slug
-          }
-        },
-        target
-      }
-    }
-  }`;
-	return await sanity.fetch(query);
+        return await sanity.fetch(NAV_QUERY);
 }
 
 export async function fetchLogoUrl(): Promise<string | null> {
-	const logoAsset = await sanity.fetch(LOGO_QUERY);
-	if (!logoAsset) return null;
-	const builder = imageUrlBuilder(sanity);
-	return builder.image(logoAsset).width(360).format('png').quality(95).url();
+        const asset = await sanity.fetch(LOGO_QUERY);
+        return asset ? builder.image(asset).width(360).format('png').quality(95).url() : null;
 }

--- a/frontend/src/lib/sanity/queries.ts
+++ b/frontend/src/lib/sanity/queries.ts
@@ -1,3 +1,27 @@
 import groq from 'groq';
 
+export const TOKEN_QUERY = groq`{
+  "light": *[_type == "designToken" && mode == "light" && isDefault == true][0],
+  "dark": *[_type == "designToken" && mode == "dark" && isDefault == true][0]
+}`;
+
+export const NAV_QUERY = groq`*[_type == "navigation" && slug.current == "main-menu"][0]{
+  items[]{
+    text,
+    link{
+      external,
+      internal->{slug}
+    },
+    target,
+    children[]{
+      text,
+      link{
+        external,
+        internal->{slug}
+      },
+      target
+    }
+  }
+}`;
+
 export const LOGO_QUERY = groq`*[_type == "siteSettings"][0].logo`;

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -3,7 +3,11 @@ import type { LayoutServerLoad } from './$types';
 import { fetchTokens, fetchNav, fetchLogoUrl } from '$lib/sanity/client';
 
 export const load: LayoutServerLoad = async () => {
-	const [tokens, navDoc, logoUrl] = await Promise.all([fetchTokens(), fetchNav(), fetchLogoUrl()]);
+        const [tokens, navigation, logoUrl] = await Promise.all([
+                fetchTokens(),
+                fetchNav(),
+                fetchLogoUrl()
+        ]);
 
-	return { tokens, navigation: navDoc || null, logoUrl };
+        return { tokens, navigation: navigation || null, logoUrl };
 };

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -170,7 +170,7 @@
 	</script>
 </svelte:head>
 
-<Header navigation={data.navigation} logoUrl={data.logoUrl} />
+<Header navigation={data.navigation} logoUrl={data.logoUrl} currentTheme={$theme} />
 
 <main class="bg-background text-foreground">
 	<div class="site-container">


### PR DESCRIPTION
## Summary
- Serve stable PNG logo URL from Sanity and expose in layout
- Pass current theme and logo to persistent header
- Restore header ThemeToggle and prevent logo blink across routes

## Testing
- `npm test` *(failed: Error: Process from config.webServer was not able to start. Exit code: 1)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898159f3a8883328036c761cb8ef3e2