### PR TITLE
Fix missing Sanity blog fetch

### DIFF
--- a/frontend/src/lib/sanity.spec.ts
+++ b/frontend/src/lib/sanity.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest'
+import { getBlogPosts } from './sanity'
+
+const fetchMock = vi.fn(() => Promise.resolve([]))
+
+vi.mock('@sanity/client', () => ({
+  createClient: () => ({ fetch: fetchMock }),
+}))
+
+test('getBlogPosts returns an array', async () => {
+  const posts = await getBlogPosts()
+  expect(Array.isArray(posts)).toBe(true)
+  expect(fetchMock).toHaveBeenCalledOnce()
+})

--- a/frontend/src/lib/sanity.ts
+++ b/frontend/src/lib/sanity.ts
@@ -3,6 +3,8 @@ import { createClient, type SanityClient } from '@sanity/client'
 import type { Navigation } from '$lib/types/navigation'
 import type { DesignToken } from '$lib/types/designToken'
 
+import type { BlogPost } from '$lib/types/blogPost'
+
 const client: SanityClient = createClient({
   projectId: 'smxz6rsz',
   dataset:   'production',
@@ -22,10 +24,24 @@ export async function getNavigation(): Promise<Navigation | null> {
     return null
   }
 }
-
 export async function getDesignToken(): Promise<DesignToken | null> {
   const tokens = await client.fetch<DesignToken[]>(`
     *[_type=="designToken"] | order(_createdAt desc)[0]
-  `)
-  return tokens[0] || null
+  `);
+  return tokens[0] || null;
+}
+export async function getBlogPosts(): Promise<BlogPost[]> {
+  const query = `*[_type=="blogPost"] | order(publishedAt desc){
+    _id,
+    title,
+    slug{current},
+    excerpt,
+    publishedAt
+  }`
+  try {
+    return await client.fetch<BlogPost[]>(query)
+  } catch (err) {
+    console.error('Sanity fetch error for blog posts:', err)
+    return []
+  }
 }

--- a/frontend/src/lib/types/blogPost.ts
+++ b/frontend/src/lib/types/blogPost.ts
@@ -1,0 +1,8 @@
+// src/lib/types/blogPost.ts
+export interface BlogPost {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  excerpt: string;
+  publishedAt: string;
+}


### PR DESCRIPTION
## Summary
- ensure blog post query returns slug and published date
- add BlogPost type with publishedAt field
- tighten unit test with explicit client mock and call verification

## Testing
- `npm install` *(fails: No matching version found for @sanity/codegen@^1.0.0)*
- `npm run test:unit --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688984b2de048332b52d5e21dad14fe0